### PR TITLE
Add simple generic Future implementation

### DIFF
--- a/pkg/future/future.go
+++ b/pkg/future/future.go
@@ -1,0 +1,57 @@
+package future
+
+import "sync"
+
+// Future type provides generic Future object.
+type Future[T any] struct {
+	valueSet bool
+	value    T
+	err      error
+	once     *sync.Once
+	wg       *sync.WaitGroup
+}
+
+// New instantiates a Future
+func New[T any]() Future[T] {
+	f := Future[T]{}
+	f.once = &sync.Once{}
+	f.wg = &sync.WaitGroup{}
+	f.wg.Add(1)
+	return f
+}
+
+func (f *Future[T]) SetError(err error) {
+	if f.valueSet {
+		panic("value already set")
+	}
+
+	f.once.Do(func() {
+		f.err = err
+		f.valueSet = true
+		f.wg.Done()
+	})
+}
+
+// SetValue sets the return value for Future.
+func (f *Future[T]) SetValue(v T) {
+	if f.valueSet {
+		panic("value already set")
+	}
+
+	f.once.Do(func() {
+		f.value = v
+		f.valueSet = true
+		f.wg.Done()
+	})
+}
+
+// Ready returns boolean, whether Future result is ready yet or not.
+func (f *Future[T]) Ready() bool {
+	return f.valueSet
+}
+
+// Result returns the result value of Future. It blocks until result becomes available.
+func (f *Future[T]) Result() (T, error) {
+	f.wg.Wait()
+	return f.value, f.err
+}

--- a/pkg/future/future_test.go
+++ b/pkg/future/future_test.go
@@ -1,0 +1,86 @@
+package future
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_Future_ReadyReturnsFalseWithoutResult(t *testing.T) {
+	f := New[int]()
+	ok := f.Ready()
+	if ok {
+		t.Fatalf("f.Ready() returned %t, expected %t", ok, false)
+	}
+}
+
+func Test_Future_ReadyReturnsTrueWithResult(t *testing.T) {
+	f := New[int]()
+
+	exp := 1
+
+	f.SetValue(exp)
+
+	ok := f.Ready()
+	if !ok {
+		t.Fatalf("f.Ready() returned %t, expected %t", ok, true)
+	}
+
+	v, _ := f.Result()
+
+	if v != exp {
+		t.Fatalf("f.Peek() returned %d, expected %d", v, exp)
+	}
+}
+
+func Test_Future_SetValueDoesNotBlock(t *testing.T) {
+	f := New[int]()
+
+	v0 := 1
+	f.SetValue(v0)
+
+	v1, _ := f.Result()
+
+	if v0 != v1 {
+		t.Fatalf("f.Result() returned %d, expected %d", v1, v0)
+	}
+}
+
+func Test_Future_SetErrorDoesNotBlock(t *testing.T) {
+	f := New[int]()
+
+	errOrig := fmt.Errorf("error")
+	f.SetError(errOrig)
+
+	_, err := f.Result()
+
+	if err != errOrig {
+		t.Fatalf("f.Result() returned %d, expected %d", err, errOrig)
+	}
+}
+
+func Test_Future_SetValueTwicePanics(t *testing.T) {
+	f := New[int]()
+
+	f.SetValue(1)
+
+	defer func() {
+		if v := recover(); v == nil {
+			t.Fatal("Future value already set once. It must not allow setting it multiple times.")
+		}
+	}()
+
+	f.SetValue(2)
+}
+
+func Test_Future_ResultTwiceSucceeds(t *testing.T) {
+	f := New[int]()
+
+	f.SetValue(1)
+
+	_, _ = f.Result()
+	v, _ := f.Result()
+
+	if v != 1 {
+		t.Fatalf("second f.Result() returned %d, expected %d", v, 1)
+	}
+}


### PR DESCRIPTION
This generic implementation can be used to communicate asynchronously
completing operation result.