### PR TITLE
Extract `blockchain.Verifier` implementation from `Avail`

### DIFF
--- a/consensus/avail/avail.go
+++ b/consensus/avail/avail.go
@@ -22,7 +22,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/hashicorp/go-hclog"
 	"github.com/maticnetwork/avail-settlement/pkg/avail"
-	"github.com/maticnetwork/avail-settlement/pkg/block"
 )
 
 const (
@@ -54,6 +53,7 @@ type Avail struct {
 
 	blockchain *blockchain.Blockchain
 	executor   *state.Executor
+	verifier   blockchain.Verifier
 
 	updateCh chan struct{} // nolint:unused // Update channel
 
@@ -74,6 +74,7 @@ func Factory(
 		closeCh:        make(chan struct{}),
 		blockchain:     params.Blockchain,
 		executor:       params.Executor,
+		verifier:       NewVerifier(logger.Named("verifier")),
 		txpool:         params.TxPool,
 		secretsManager: params.SecretsManager,
 		network:        params.Network,
@@ -177,41 +178,20 @@ func (d *Avail) setState(s AvailState) {
 // REQUIRED BASE INTERFACE METHODS //
 
 func (d *Avail) VerifyHeader(header *types.Header) error {
-
-	signer, err := block.AddressRecoverFromHeader(header)
-	if err != nil {
-		return err
-	}
-
-	d.logger.Info("Verify header", "signer", signer.String())
-
-	if signer != types.StringToAddress(SequencerAddress) {
-		d.logger.Info("Passing, how is it possible? 222")
-		return fmt.Errorf("signer address '%s' does not match sequencer address '%s'", signer, SequencerAddress)
-	}
-
-	d.logger.Info("Seal signer address successfully verified!", "signer", signer, "sequencer", SequencerAddress)
-
-	return nil
-}
-
-// PreCommitState a hook to be called before finalizing state transition on inserting block
-func (d *Avail) PreCommitState(_header *types.Header, _txn *state.Transition) error {
-	return nil
+	return d.verifier.VerifyHeader(header)
 }
 
 func (d *Avail) ProcessHeaders(headers []*types.Header) error {
-	return nil
+	return d.verifier.ProcessHeaders(headers)
 }
 
 func (d *Avail) GetBlockCreator(header *types.Header) (types.Address, error) {
-	//return addressRecoverFromHeader(header)
-	return types.BytesToAddress(header.Miner), nil
+	return d.verifier.GetBlockCreator(header)
 }
 
-// PreStateCommit a hook to be called before finalizing state transition on inserting block
-func (d *Avail) PreStateCommit(_header *types.Header, _txn *state.Transition) error {
-	return nil
+// PreCommitState a hook to be called before finalizing state transition on inserting block
+func (d *Avail) PreCommitState(header *types.Header, tx *state.Transition) error {
+	return d.verifier.PreCommitState(header, tx)
 }
 
 func (d *Avail) GetSyncProgression() *progress.Progression {

--- a/consensus/avail/verifier.go
+++ b/consensus/avail/verifier.go
@@ -1,0 +1,78 @@
+package avail
+
+import (
+	"fmt"
+
+	"github.com/0xPolygon/polygon-edge/blockchain"
+	"github.com/0xPolygon/polygon-edge/state"
+	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/hashicorp/go-hclog"
+	"github.com/maticnetwork/avail-settlement/pkg/block"
+)
+
+type verifier struct {
+	logger hclog.Logger
+}
+
+func NewVerifier(logger hclog.Logger) blockchain.Verifier {
+	return &verifier{
+		logger: logger,
+	}
+}
+
+func (v *verifier) VerifyHeader(header *types.Header) error {
+	signer, err := block.AddressRecoverFromHeader(header)
+	if err != nil {
+		return err
+	}
+
+	v.logger.Info("Verify header", "signer", signer.String())
+
+	if signer != types.StringToAddress(SequencerAddress) {
+		v.logger.Info("Passing, how is it possible? 222")
+		return fmt.Errorf("signer address '%s' does not match sequencer address '%s'", signer, SequencerAddress)
+	}
+
+	v.logger.Info("Seal signer address successfully verified!", "signer", signer, "sequencer", SequencerAddress)
+
+	/*
+		parent, ok := i.blockchain.GetHeaderByNumber(header.Number - 1)
+		if !ok {
+			return fmt.Errorf(
+				"unable to get parent header for block number %d",
+				header.Number,
+			)
+		}
+
+		snap, err := i.getSnapshot(parent.Number)
+		if err != nil {
+			return err
+		}
+
+		// verify all the header fields + seal
+		if err := i.verifyHeaderImpl(snap, parent, header); err != nil {
+			return err
+		}
+
+		// verify the committed seals
+		if err := verifyCommittedFields(snap, header, i.quorumSize(header.Number)); err != nil {
+			return err
+		}
+
+		return nil
+	*/
+	return nil
+}
+
+func (v *verifier) ProcessHeaders(headers []*types.Header) error {
+	return nil
+}
+
+func (v *verifier) GetBlockCreator(header *types.Header) (types.Address, error) {
+	return types.BytesToAddress(header.Miner), nil
+}
+
+// PreCommitState a hook to be called before finalizing state transition on inserting block
+func (v *verifier) PreCommitState(_header *types.Header, _txn *state.Transition) error {
+	return nil
+}


### PR DESCRIPTION
Separate blockchain verification related functionality from other P2P and server related operations so that this functionality can be used in unit tests later on.

Since `consensus.Consensus` embeds `blockchain.Verifier`, `Avail` implementation now delegates those functions to dedicated `verifier`.