### PR TITLE
Introduce basic support for Avail consensus tests

### DIFF
--- a/consensus/avail/tests/common_test.go
+++ b/consensus/avail/tests/common_test.go
@@ -104,7 +104,6 @@ func (bbf *BasicBlockFactory) BuildBlock(parent *types.Block, txs []*types.Trans
 	return blk
 }
 
-// nolint:unused
 func newAccount(t *testing.T) (types.Address, *ecdsa.PrivateKey) {
 	t.Helper()
 
@@ -119,7 +118,6 @@ func newAccount(t *testing.T) (types.Address, *ecdsa.PrivateKey) {
 	return address, privateKey
 }
 
-// nolint:unused
 func newBlockchain(t *testing.T) (*state.Executor, *blockchain.Blockchain) {
 	chain := newChain(t)
 	executor := newInMemExecutor(t, chain)
@@ -144,7 +142,6 @@ func newBlockchain(t *testing.T) (*state.Executor, *blockchain.Blockchain) {
 	return executor, bchain
 }
 
-// nolint:unused
 func newInMemExecutor(t *testing.T, c *chain.Chain) *state.Executor {
 	t.Helper()
 
@@ -159,7 +156,6 @@ func newInMemExecutor(t *testing.T, c *chain.Chain) *state.Executor {
 	return e
 }
 
-// nolint:unused
 func newChain(t *testing.T) *chain.Chain {
 	balance := new(big.Int)
 	balance.SetString("0x3635c9adc5dea00000", 16)
@@ -193,7 +189,6 @@ func newChain(t *testing.T) *chain.Chain {
 	}
 }
 
-// nolint:unused
 func getHeadBlock(t *testing.T, blockchain *blockchain.Blockchain) *types.Block {
 	var head *types.Block
 

--- a/consensus/avail/tests/validator_test.go
+++ b/consensus/avail/tests/validator_test.go
@@ -1,0 +1,126 @@
+package tests
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/maticnetwork/avail-settlement/consensus/avail/validator"
+)
+
+func TestValidatorBlockCheck(t *testing.T) {
+	testCases := []struct {
+		name         string
+		block        func(bf BlockFactory, parent *types.Block) *types.Block
+		errorMatcher func(err error) bool
+	}{
+		{
+			name:         "zero block",
+			block:        func(bf BlockFactory, parent *types.Block) *types.Block { return &types.Block{} },
+			errorMatcher: func(err error) bool { return errors.Is(err, validator.ErrInvalidBlock) },
+		},
+		{
+			name:  "coinbase block",
+			block: func(bf BlockFactory, parent *types.Block) *types.Block { return bf.BuildBlock(parent, nil) },
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("case %d: %s", i, tc.name), func(t *testing.T) {
+			executor, blockchain := newBlockchain(t)
+			coinbaseAddr, signKey := newAccount(t)
+			bf := NewBasicBlockFactory(t, executor, coinbaseAddr, signKey)
+
+			v := validator.New(blockchain, executor, coinbaseAddr)
+
+			head := getHeadBlock(t, blockchain)
+
+			err := v.Check(tc.block(bf, head))
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// correct; carry on
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+		})
+	}
+}
+
+func TestValidatorApplyBlockToBlockchain(t *testing.T) {
+	testCases := []struct {
+		name         string
+		block        func(bf BlockFactory, parent *types.Block) *types.Block
+		errorMatcher func(err error) bool
+	}{
+		{
+			name:  "coinbase block",
+			block: func(bf BlockFactory, parent *types.Block) *types.Block { return bf.BuildBlock(parent, nil) },
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("case %d: %s", i, tc.name), func(t *testing.T) {
+			executor, blockchain := newBlockchain(t)
+			coinbaseAddr, signKey := newAccount(t)
+			bf := NewBasicBlockFactory(t, executor, coinbaseAddr, signKey)
+
+			v := validator.New(blockchain, executor, coinbaseAddr)
+
+			head := getHeadBlock(t, blockchain)
+
+			err := v.Apply(tc.block(bf, head))
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// correct; carry on
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+		})
+	}
+}
+
+func TestValidatorProcessesFraudproof(t *testing.T) {
+	testCases := []struct {
+		name         string
+		block        func(bf BlockFactory, parent *types.Block) *types.Block
+		errorMatcher func(err error) bool
+	}{
+		{
+			name:  "coinbase block",
+			block: func(bf BlockFactory, parent *types.Block) *types.Block { return bf.BuildBlock(parent, nil) },
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("case %d: %s", i, tc.name), func(t *testing.T) {
+			executor, blockchain := newBlockchain(t)
+			coinbaseAddr, signKey := newAccount(t)
+			bf := NewBasicBlockFactory(t, executor, coinbaseAddr, signKey)
+
+			v := validator.New(blockchain, executor, coinbaseAddr)
+
+			head := getHeadBlock(t, blockchain)
+
+			err := v.ProcessFraudproof(tc.block(bf, head))
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// correct; carry on
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+		})
+	}
+}

--- a/consensus/avail/validator/validator.go
+++ b/consensus/avail/validator/validator.go
@@ -1,0 +1,300 @@
+package validator
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"github.com/0xPolygon/polygon-edge/blockchain"
+	"github.com/0xPolygon/polygon-edge/state"
+	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/0xPolygon/polygon-edge/types/buildroot"
+	"github.com/hashicorp/go-hclog"
+	"github.com/maticnetwork/avail-settlement/pkg/block"
+)
+
+/****************************************************************************/
+
+// For now hand coded address of the sequencer
+const SequencerAddress = "0xF817d12e6933BbA48C14D4c992719B46aD9f5f61"
+
+var (
+	// ErrInvalidBlock is general error used when block structure is invalid
+	// or its field values are inconsistent.
+	ErrInvalidBlock         = errors.New("invalid block")
+	ErrInvalidBlockSequence = errors.New("invalid block sequence")
+	ErrInvalidParentHash    = errors.New("parent block hash is invalid")
+	ErrInvalidSha3Uncles    = errors.New("invalid block sha3 uncles root")
+	ErrInvalidTxRoot        = errors.New("invalid block transactions root")
+	ErrNoBlock              = errors.New("no block data passed in")
+	ErrParentHashMismatch   = errors.New("invalid parent block hash")
+	ErrParentNotFound       = errors.New("parent block not found")
+)
+
+type Validator interface {
+	Apply(block *types.Block) error
+	Check(block *types.Block) error
+	ProcessFraudproof(block *types.Block) error
+}
+
+type ValidatorSet []types.Address
+
+type validator struct {
+	blockchain *blockchain.Blockchain
+	executor   *state.Executor
+
+	logger           hclog.Logger
+	sequencerAddress types.Address
+}
+
+func New(blockchain *blockchain.Blockchain, executor *state.Executor, sequencer types.Address) Validator {
+	return &validator{
+		blockchain: blockchain,
+		executor:   executor,
+
+		logger:           hclog.Default(),
+		sequencerAddress: sequencer,
+	}
+}
+
+func (v *validator) Apply(blk *types.Block) error {
+	if err := v.blockchain.WriteBlock(blk, block.SourceAvail); err != nil {
+		return fmt.Errorf("failed to write block while bulk syncing: %w", err)
+	}
+
+	v.logger.Debug("Received block header: %+v \n", blk.Header)
+	v.logger.Debug("Received block transactions: %+v \n", blk.Transactions)
+
+	return nil
+}
+
+func (v *validator) Check(blk *types.Block) error {
+	if blk.Header == nil {
+		return fmt.Errorf("%w: block.Header == nil", ErrInvalidBlock)
+	}
+
+	if err := v.verifyFinalizedBlock(blk); err != nil {
+		return fmt.Errorf("unable to verify block, %w", err)
+	}
+	return nil
+}
+
+func (v *validator) ProcessFraudproof(blk *types.Block) error {
+	extraData := blk.Header.ExtraData
+	if len(extraData) > 0 && bytes.Contains(extraData, block.FraudproofPrefix) {
+		v.logger.Warn("**************** FRAUD PROOF FOUND ************************")
+		addr := bytes.TrimPrefix(extraData, block.FraudproofPrefix)
+		if len(addr) < types.HashLength*2 {
+			return fmt.Errorf("invalid fraud proof block: %d/%q - target block hash invalid", blk.Number(), blk.Hash())
+		}
+
+		var hash types.Hash
+		err := hash.Scan(addr[:types.HashLength*2])
+		if err != nil {
+			return fmt.Errorf("invalid fraud proof block: %d/%q - cannot parse target block hash: %s", blk.Number(), blk.Hash(), err)
+		}
+
+		// TODO(tuommaki): Process fraud proof.
+	}
+
+	return nil
+}
+
+// verifyFinalizedBlock is modified version of `blockchain.Blockchain.VerifyFinalizedBlock()`
+func (v *validator) verifyFinalizedBlock(blk *types.Block) error {
+	// Make sure the consensus layer verifies this block header
+	if err := v.verifyHeader(blk.Header); err != nil {
+		return fmt.Errorf("failed to verify the header: %w", err)
+	}
+
+	// Do the initial block verification
+	if err := v.verifyBlock(blk); err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
+// verifyBlock does the base (common) block verification steps by
+// verifying the block body as well as the parent information
+func (v *validator) verifyBlock(blk *types.Block) error {
+	// Make sure the block is present
+	if blk == nil {
+		return ErrNoBlock
+	}
+
+	// Make sure the block is in line with the parent block
+	if err := v.verifyBlockParent(blk); err != nil {
+		return err
+	}
+
+	// Make sure the block body data is valid
+	if err := v.verifyBlockBody(blk); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (v *validator) verifyHeader(header *types.Header) error {
+	signer, err := block.AddressRecoverFromHeader(header)
+	if err != nil {
+		return err
+	}
+
+	v.logger.Info("Verify header", "signer", signer.String())
+
+	if signer != v.sequencerAddress {
+		v.logger.Info("Passing, how is it possible? 222")
+		return fmt.Errorf("signer address '%s' does not match sequencer address '%s'", signer, SequencerAddress)
+	}
+
+	v.logger.Info("Seal signer address successfully verified!", "signer", signer, "sequencer", SequencerAddress)
+
+	/*
+		parent, ok := i.blockchain.GetHeaderByNumber(header.Number - 1)
+		if !ok {
+			return fmt.Errorf(
+				"unable to get parent header for block number %d",
+				header.Number,
+			)
+		}
+
+		snap, err := i.getSnapshot(parent.Number)
+		if err != nil {
+			return err
+		}
+
+		// verify all the header fields + seal
+		if err := i.verifyHeaderImpl(snap, parent, header); err != nil {
+			return err
+		}
+
+		// verify the committed seals
+		if err := verifyCommittedFields(snap, header, i.quorumSize(header.Number)); err != nil {
+			return err
+		}
+
+		return nil
+	*/
+	return nil
+}
+
+// verifyBlockParent makes sure that the child block is in line
+// with the locally saved parent block. This means checking:
+// - The parent exists
+// - The hashes match up
+// - The block numbers match up
+// - The block gas limit / used matches up
+func (v *validator) verifyBlockParent(childBlk *types.Block) error {
+	// Grab the parent block
+	parentHash := childBlk.ParentHash()
+	parent, ok := v.blockchain.GetHeaderByHash(parentHash)
+
+	if !ok {
+		v.logger.Error(fmt.Sprintf(
+			"parent of %s (%d) not found: %s",
+			childBlk.Hash().String(),
+			childBlk.Number(),
+			parentHash,
+		))
+
+		return ErrParentNotFound
+	}
+
+	// Make sure the hash is valid
+	if parent.Hash == types.ZeroHash {
+		return ErrInvalidParentHash
+	}
+
+	// Make sure the hashes match up
+	if parentHash != parent.Hash {
+		return ErrParentHashMismatch
+	}
+
+	// Make sure the block numbers are correct
+	if childBlk.Number()-1 != parent.Number {
+		v.logger.Error(fmt.Sprintf(
+			"number sequence not correct at %d and %d",
+			childBlk.Number(),
+			parent.Number,
+		))
+
+		return ErrInvalidBlockSequence
+	}
+
+	// Make sure the gas limit is within correct bounds
+	if gasLimitErr := v.verifyGasLimit(childBlk.Header, parent); gasLimitErr != nil {
+		return fmt.Errorf("invalid gas limit, %w", gasLimitErr)
+	}
+
+	return nil
+}
+
+// verifyGasLimit is a helper function for validating a gas limit in a header
+func (v *validator) verifyGasLimit(header *types.Header, parentHeader *types.Header) error {
+	if header.GasUsed > header.GasLimit {
+		return fmt.Errorf(
+			"block gas used exceeds gas limit, limit = %d, used=%d",
+			header.GasLimit,
+			header.GasUsed,
+		)
+	}
+
+	// Skip block limit difference check for genesis
+	if header.Number == 0 {
+		return nil
+	}
+
+	// Find the absolute delta between the limits
+	diff := int64(parentHeader.GasLimit) - int64(header.GasLimit)
+	if diff < 0 {
+		diff *= -1
+	}
+
+	limit := parentHeader.GasLimit / blockchain.BlockGasTargetDivisor
+	if uint64(diff) > limit {
+		return fmt.Errorf(
+			"invalid gas limit, limit = %d, want %d +- %d",
+			header.GasLimit,
+			parentHeader.GasLimit,
+			limit-1,
+		)
+	}
+
+	return nil
+}
+
+// verifyBlockBody verifies that the block body is valid. This means checking:
+// - The trie roots match up (state, transactions, receipts, uncles)
+// - The receipts match up
+// - The execution result matches up
+func (v *validator) verifyBlockBody(blk *types.Block) error {
+	// Make sure the Uncles root matches up
+	if hash := buildroot.CalculateUncleRoot(blk.Uncles); hash != blk.Header.Sha3Uncles {
+		v.logger.Error(fmt.Sprintf(
+			"uncle root hash mismatch: have %s, want %s",
+			hash,
+			blk.Header.Sha3Uncles,
+		))
+
+		return ErrInvalidSha3Uncles
+	}
+
+	// Make sure the transactions root matches up
+	if hash := buildroot.CalculateTransactionsRoot(blk.Transactions); hash != blk.Header.TxRoot {
+		v.logger.Error(fmt.Sprintf(
+			"transaction root hash mismatch: have %s, want %s",
+			hash,
+			blk.Header.TxRoot,
+		))
+
+		return ErrInvalidTxRoot
+	}
+
+	// Transaction execution skipped, contrary to
+	// `blockchain.Blockchain.verifyBlockBody()` implementation.
+
+	return nil
+}

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -1,0 +1,6 @@
+package block
+
+const (
+	// SourceAvail is the constant for Avail as a block source.
+	SourceAvail = "Avail"
+)

--- a/pkg/block/extra.go
+++ b/pkg/block/extra.go
@@ -8,6 +8,10 @@ import (
 )
 
 var (
+	// FraudproofPrefix is byte sequence that prefixes the fraudproof objected
+	// malicious block hash in `ExtraData` of the fraudproof block header.
+	FraudproofPrefix = []byte("FRAUDPROOF_OF:")
+
 	// SequencerExtraVanity represents a fixed number of extra-data bytes reserved for proposer vanity
 	SequencerExtraVanity = 128
 )

--- a/pkg/block/seal.go
+++ b/pkg/block/seal.go
@@ -9,10 +9,6 @@ import (
 	"github.com/umbracle/fastrlp"
 )
 
-// FraudproofPrefix is byte sequence that prefixes the fraudproof objected
-// malicious block hash in `ExtraData` of the fraudproof block header.
-var FraudproofPrefix = []byte("FRAUDPROOF_OF:")
-
 // WriteSeal signs the block and writes serialized `ValidatorExtra` into
 // block's `ExtraData`.
 func WriteSeal(prv *ecdsa.PrivateKey, h *types.Header) (*types.Header, error) {


### PR DESCRIPTION
With separate `tests` package, consensus tests ensure that consensus functionality gets tested only via external interface and therefore enforces boundary for separation of concerns.