### PR TITLE
Move `blockchain.Verifier` implementation to own package

### DIFF
--- a/consensus/avail/avail.go
+++ b/consensus/avail/avail.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/hashicorp/go-hclog"
+	"github.com/maticnetwork/avail-settlement/consensus/avail/verifier"
 	"github.com/maticnetwork/avail-settlement/pkg/avail"
 )
 
@@ -74,7 +75,7 @@ func Factory(
 		closeCh:        make(chan struct{}),
 		blockchain:     params.Blockchain,
 		executor:       params.Executor,
-		verifier:       NewVerifier(logger.Named("verifier")),
+		verifier:       verifier.New(logger.Named("verifier")),
 		txpool:         params.TxPool,
 		secretsManager: params.SecretsManager,
 		network:        params.Network,

--- a/consensus/avail/tests/common_test.go
+++ b/consensus/avail/tests/common_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/hashicorp/go-hclog"
-	"github.com/maticnetwork/avail-settlement/consensus/avail"
+	"github.com/maticnetwork/avail-settlement/consensus/avail/verifier"
 	"github.com/maticnetwork/avail-settlement/pkg/block"
 )
 
@@ -130,7 +130,7 @@ func newBlockchain(t *testing.T) (*state.Executor, *blockchain.Blockchain) {
 		t.Fatal(err)
 	}
 
-	bchain.SetConsensus(avail.NewVerifier(hclog.Default()))
+	bchain.SetConsensus(verifier.New(hclog.Default()))
 
 	executor.GetHash = bchain.GetHashHelper
 

--- a/consensus/avail/verifier/verifier.go
+++ b/consensus/avail/verifier/verifier.go
@@ -1,4 +1,4 @@
-package avail
+package verifier
 
 import (
 	"fmt"
@@ -10,11 +10,16 @@ import (
 	"github.com/maticnetwork/avail-settlement/pkg/block"
 )
 
+var (
+	// XXX: For now hand coded address of the sequencer. Will be removed soon.
+	SequencerAddress = "0xF817d12e6933BbA48C14D4c992719B46aD9f5f61"
+)
+
 type verifier struct {
 	logger hclog.Logger
 }
 
-func NewVerifier(logger hclog.Logger) blockchain.Verifier {
+func New(logger hclog.Logger) blockchain.Verifier {
 	return &verifier{
 		logger: logger,
 	}


### PR DESCRIPTION
In order to avoid import cycles, move `blockchain.Verifier` implementation into own package.