### PR TITLE
Move `verifier.Verifier` to `block` to avoid import cycle

### DIFF
--- a/consensus/avail/avail.go
+++ b/consensus/avail/avail.go
@@ -21,8 +21,8 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/hashicorp/go-hclog"
-	"github.com/maticnetwork/avail-settlement/consensus/avail/verifier"
 	"github.com/maticnetwork/avail-settlement/pkg/avail"
+	"github.com/maticnetwork/avail-settlement/pkg/block"
 )
 
 const (
@@ -75,7 +75,7 @@ func Factory(
 		closeCh:        make(chan struct{}),
 		blockchain:     params.Blockchain,
 		executor:       params.Executor,
-		verifier:       verifier.New(logger.Named("verifier")),
+		verifier:       block.NewVerifier(logger.Named("verifier")),
 		txpool:         params.TxPool,
 		secretsManager: params.SecretsManager,
 		network:        params.Network,

--- a/consensus/avail/tests/common_test.go
+++ b/consensus/avail/tests/common_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/hashicorp/go-hclog"
-	"github.com/maticnetwork/avail-settlement/consensus/avail/verifier"
 	"github.com/maticnetwork/avail-settlement/pkg/block"
 )
 
@@ -130,7 +129,7 @@ func newBlockchain(t *testing.T) (*state.Executor, *blockchain.Blockchain) {
 		t.Fatal(err)
 	}
 
-	bchain.SetConsensus(verifier.New(hclog.Default()))
+	bchain.SetConsensus(block.NewVerifier(hclog.Default()))
 
 	executor.GetHash = bchain.GetHashHelper
 

--- a/pkg/block/verifier.go
+++ b/pkg/block/verifier.go
@@ -1,4 +1,4 @@
-package verifier
+package block
 
 import (
 	"fmt"
@@ -7,7 +7,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/state"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/hashicorp/go-hclog"
-	"github.com/maticnetwork/avail-settlement/pkg/block"
 )
 
 var (
@@ -19,14 +18,14 @@ type verifier struct {
 	logger hclog.Logger
 }
 
-func New(logger hclog.Logger) blockchain.Verifier {
+func NewVerifier(logger hclog.Logger) blockchain.Verifier {
 	return &verifier{
 		logger: logger,
 	}
 }
 
 func (v *verifier) VerifyHeader(header *types.Header) error {
-	signer, err := block.AddressRecoverFromHeader(header)
+	signer, err := AddressRecoverFromHeader(header)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Block manipulation logic is needed in many unit tests. So is the blockchain itself, which then again needs the block verification implementation. To avoid import cycles, put block verifier into `block` package.
