### PR TITLE
Add support for arbitrary key-values in `ExtraData`

### DIFF
--- a/consensus/avail/blocks.go
+++ b/consensus/avail/blocks.go
@@ -92,7 +92,10 @@ func (d *Avail) buildBlock(minerKeystore *keystore.KeyStore, minerAccount accoun
 	header.Timestamp = uint64(headerTime.Unix())
 
 	// we need to include in the extra field the current set of validators
-	block.AssignExtraValidators(header, ValidatorSet{types.StringToAddress(minerAccount.Address.Hex())})
+	err = block.AssignExtraValidators(header, ValidatorSet{types.StringToAddress(minerAccount.Address.Hex())})
+	if err != nil {
+		return nil, err
+	}
 
 	transition, err := d.executor.BeginTxn(parent.StateRoot, header, types.StringToAddress(minerAccount.Address.Hex()))
 	if err != nil {

--- a/consensus/avail/sequencer.go
+++ b/consensus/avail/sequencer.go
@@ -139,7 +139,10 @@ func (d *Avail) writeNewBlock(minerKeystore *keystore.KeyStore, minerAccount acc
 	header.Timestamp = uint64(headerTime.Unix())
 
 	// we need to include in the extra field the current set of validators
-	block.AssignExtraValidators(header, ValidatorSet{types.StringToAddress(minerAccount.Address.Hex())})
+	err = block.AssignExtraValidators(header, ValidatorSet{types.StringToAddress(minerAccount.Address.Hex())})
+	if err != nil {
+		return err
+	}
 
 	transition, err := d.executor.BeginTxn(parent.StateRoot, header, types.StringToAddress(minerAccount.Address.Hex()))
 	if err != nil {

--- a/pkg/block/builder_test.go
+++ b/pkg/block/builder_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"math/big"
+	"reflect"
 	"testing"
 
 	edge_crypto "github.com/0xPolygon/polygon-edge/crypto"
@@ -171,6 +172,31 @@ func Test_Builder_Add_Transaction(t *testing.T) {
 
 	if tx.Value.Cmp(amount) != 0 {
 		t.Fatalf("expected %q, got %q in tx.Value", tx.Value, amount)
+	}
+}
+
+func Test_Builder_Set_ExtraData(t *testing.T) {
+	sk := newPrivateKey(t)
+
+	key := "foo"
+	value := []byte("bar")
+
+	b, err := newBlockBuilder(t).
+		SetExtraDataField(key, value).
+		SignWith(sk).
+		Build()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	kv, err := DecodeExtraDataFields(b.Header.ExtraData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(kv["foo"], value) {
+		t.Fatalf("block header ExtraData[%q]: got %v, expected %v", "foo", kv["foo"], value)
 	}
 }
 

--- a/pkg/block/extra_test.go
+++ b/pkg/block/extra_test.go
@@ -1,0 +1,92 @@
+package block
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"testing"
+
+	"github.com/maticnetwork/avail-settlement/pkg/test"
+)
+
+func Test_ExtraData_Encoding(t *testing.T) {
+	key := func() string {
+		min, max := 2, 32
+		return string(test.RandomBytes(t, rand.Intn(max-min)+min))
+	}
+
+	value := func() []byte {
+		min, max := 2, 256
+		return test.RandomBytes(t, rand.Intn(max-min)+min)
+	}
+
+	TestRounds := 100
+
+	for i := 0; i < TestRounds; i++ {
+		kv := make(map[string][]byte)
+		n := rand.Intn(64)
+		for j := 0; j < n; j++ {
+			kv[key()] = value()
+		}
+
+		bs := EncodeExtraDataFields(kv)
+		decodedKV, err := DecodeExtraDataFields(bs)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for k, v := range kv {
+			v2, exists := decodedKV[k]
+			if !exists {
+				t.Fatalf("couldn't find key %q from decoded key values", k)
+			}
+
+			if !reflect.DeepEqual(v, v2) {
+				t.Fatalf("v != v2; got len(v): %d, len(v2): %d", len(v), len(v2))
+			}
+
+			delete(decodedKV, k)
+		}
+
+		if len(decodedKV) > 0 {
+			t.Fatalf("len(decodedKV): %d, expected 0", len(decodedKV))
+		}
+	}
+}
+
+func Test_ExtraData_Decoding(t *testing.T) {
+	testCases := []struct {
+		name         string
+		input        []byte
+		expected     map[string][]byte
+		errorMatcher func(error) bool
+	}{
+		{
+			name:         "nil input",
+			input:        nil,
+			expected:     make(map[string][]byte),
+			errorMatcher: nil,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("case %d: %s", i, tc.name), func(t *testing.T) {
+			kv, err := DecodeExtraDataFields(tc.input)
+
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// correct; carry on
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if !reflect.DeepEqual(kv, tc.expected) {
+				t.Fatalf("expected %#v, got %#v", tc.expected, kv)
+			}
+		})
+	}
+}

--- a/pkg/block/seal.go
+++ b/pkg/block/seal.go
@@ -64,7 +64,10 @@ func calculateHeaderHash(h *types.Header) ([]byte, error) {
 	// This will effectively remove the Seal and Committed Seal fields,
 	// while keeping proposer vanity and validator set
 	// because extra.Validators is what we got from `h` in the first place.
-	AssignExtraValidators(h, extra.Validators)
+	err = AssignExtraValidators(h, extra.Validators)
+	if err != nil {
+		return nil, err
+	}
 
 	vv := arena.NewArray()
 	vv.Set(arena.NewBytes(h.ParentHash.Bytes()))


### PR DESCRIPTION
Block header's `ExtraData` field can carry arbitrary extra data from block forger to validator. This field is used to e.g. sign the block with sequencer's private key and it's used by watch tower to denote which block the fraud proof is attesting for.

The interface uses arbitrary `map[string][]byte` which is underneath serialized into array of string-bytes tuples.