### PR TITLE
Fix log messages

### DIFF
--- a/consensus/avail/sync.go
+++ b/consensus/avail/sync.go
@@ -16,7 +16,7 @@ func (d *Avail) runSyncState() {
 	}
 
 	callInsertBlockHook := func(block *types.Block) bool {
-		d.logger.Debug("syncing block %d", block.Number())
+		d.logger.Debug("syncing block", "block_number", block.Number(), "block_hash", block.Hash())
 		d.txpool.ResetWithHeaders(block.Header)
 		return false
 	}
@@ -33,6 +33,6 @@ func (d *Avail) runSyncState() {
 	if err := d.syncer.Sync(
 		callInsertBlockHook,
 	); err != nil {
-		d.logger.Error("watch sync failed", "err", err)
+		d.logger.Error("watch sync failed", "error", err)
 	}
 }

--- a/consensus/avail/validator.go
+++ b/consensus/avail/validator.go
@@ -36,19 +36,19 @@ func (d *Avail) runValidator() {
 
 		blk, err := block.FromAvail(avail_blk, avail.BridgeAppID, callIdx)
 		if err != nil {
-			d.logger.Error("cannot extract Edge block from Avail block %d: %s", avail_blk.Block.Header.Number, err)
+			d.logger.Error("cannot extract Edge block from Avail block", "avail_block_number", avail_blk.Block.Header.Number, "error", err)
 			continue
 		}
 
 		err = validator.Check(blk)
 		if err != nil {
-			d.logger.Error("invalid block %d/%q : %s", blk.Header.Number, blk.Header.Hash, err)
+			d.logger.Error("invalid block", "block_number", blk.Header.Number, "block_hash", blk.Header.Hash, "error", err)
 			continue
 		}
 
 		err = validator.Apply(blk)
 		if err != nil {
-			d.logger.Error("cannot apply block %d/%q to blockchain: %s", blk.Header.Number, blk.Header.Hash, err)
+			d.logger.Error("cannot apply block to blockchain", "block_nubmer", blk.Header.Number, "block_hash", blk.Header.Hash, "error", err)
 		}
 	}
 }

--- a/consensus/avail/validator/validator.go
+++ b/consensus/avail/validator/validator.go
@@ -61,8 +61,8 @@ func (v *validator) Apply(blk *types.Block) error {
 		return fmt.Errorf("failed to write block while bulk syncing: %w", err)
 	}
 
-	v.logger.Debug("Received block header: %+v \n", blk.Header)
-	v.logger.Debug("Received block transactions: %+v \n", blk.Transactions)
+	v.logger.Debug("Received block header", "header", blk.Header)
+	v.logger.Debug("Received block transactions", "transactions", blk.Transactions)
 
 	return nil
 }
@@ -190,12 +190,12 @@ func (v *validator) verifyBlockParent(childBlk *types.Block) error {
 	parent, ok := v.blockchain.GetHeaderByHash(parentHash)
 
 	if !ok {
-		v.logger.Error(fmt.Sprintf(
-			"parent of %s (%d) not found: %s",
-			childBlk.Hash().String(),
-			childBlk.Number(),
-			parentHash,
-		))
+		v.logger.Error(
+			"parent not found",
+			"child_block_hash", childBlk.Hash().String(),
+			"child_block_number", childBlk.Number(),
+			"parent_block_hash", parentHash,
+		)
 
 		return ErrParentNotFound
 	}
@@ -212,11 +212,11 @@ func (v *validator) verifyBlockParent(childBlk *types.Block) error {
 
 	// Make sure the block numbers are correct
 	if childBlk.Number()-1 != parent.Number {
-		v.logger.Error(fmt.Sprintf(
-			"number sequence not correct at %d and %d",
-			childBlk.Number(),
-			parent.Number,
-		))
+		v.logger.Error(
+			"block number sequence not correct",
+			"child_block_number", childBlk.Number(),
+			"parent_block_number", parent.Number,
+		)
 
 		return ErrInvalidBlockSequence
 	}

--- a/pkg/avail/stream.go
+++ b/pkg/avail/stream.go
@@ -57,7 +57,7 @@ func (bs *BlockStream) watch() {
 	for {
 		latest, err := bs.api.RPC.Chain.GetBlockHashLatest()
 		if err != nil {
-			bs.logger.Error("couldn't fetch latest block hash: %s", err)
+			bs.logger.Error("couldn't fetch latest block hash", "error", err)
 			continue
 		}
 
@@ -74,14 +74,14 @@ func (bs *BlockStream) watch() {
 		} else {
 			blockHash, err = bs.api.RPC.Chain.GetBlockHash(bs.offset)
 			if err != nil {
-				bs.logger.Error("couldn't fetch block hash for block number %d: %s", bs.offset, err)
+				bs.logger.Error("couldn't fetch block hash for block", "block_number", bs.offset, "error", err)
 				continue
 			}
 		}
 
 		blk, err := bs.api.RPC.Chain.GetBlock(blockHash)
 		if err != nil {
-			bs.logger.Error("couldn't fetch block: %d: %s", bs.offset, err)
+			bs.logger.Error("couldn't fetch block", "block_number", bs.offset, "block_hash", blockHash, "error", err)
 			continue
 		}
 

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -27,16 +27,14 @@ func FromAvail(avail_blk *avail_types.SignedBlock, appID uint32, callIdx avail_t
 
 	for i, extrinsic := range avail_blk.Block.Extrinsics {
 		if extrinsic.Signature.AppID != avail_types.U32(appID) {
-			logger.Debug("block %d extrinsic %d: AppID doesn't match (%d vs. %d)", avail_blk.Block.Header.Number, i, extrinsic.Signature.AppID, appID)
+			logger.Debug("block extrinsic's  AppID doesn't match", "avail_block_number", avail_blk.Block.Header.Number, "extrinsic_index", i, "extrinsic_app_id", extrinsic.Signature.AppID, "filter_app_id", appID)
 			continue
 		}
 
 		if extrinsic.Method.CallIndex != callIdx {
-			logger.Debug("block %d extrinsic %d: Method.CallIndex doesn't match (got %v, expected %v)", avail_blk.Block.Header.Number, i, extrinsic.Method.CallIndex, callIdx)
+			logger.Debug("block extrinsic's Method.CallIndex doesn't match", "avail_block_number", avail_blk.Block.Header.Number, "extrinsic_index", i, "extrinsic_call_index", extrinsic.Method.CallIndex, "filter_call_index", callIdx)
 			continue
 		}
-
-		logger.Debug("block %d extrinsic %d: len(extrinsic.Method.Args): %d, extrinsic.Method.Args: '%v'", avail_blk.Block.Header.Number, i, len(extrinsic.Method.Args), extrinsic.Method.Args)
 
 		var blob avail.Blob
 		{
@@ -50,7 +48,7 @@ func FromAvail(avail_blk *avail_types.SignedBlock, appID uint32, callIdx avail_t
 				// Don't return just yet because there is no way of filtering
 				// uninteresting extrinsics / method.Args and failing decoding
 				// is the only way to distinct those.
-				logger.Debug("block %d extrinsic %d: decoding raw bytes from args failed: %s", avail_blk.Block.Header.Number, i, err)
+				logger.Debug("decoding block extrinsic's raw bytes from args failed", "avail_block_number", avail_blk.Block.Header.Number, "extrinsic_index", i, "error", err)
 				continue
 			}
 
@@ -60,7 +58,7 @@ func FromAvail(avail_blk *avail_types.SignedBlock, appID uint32, callIdx avail_t
 				// Don't return just yet because there is no way of filtering
 				// uninteresting extrinsics / method.Args and failing decoding
 				// is the only way to distinct those.
-				logger.Debug("block %d extrinsic %d: decoding blob from bytes failed: %s", avail_blk.Block.Header.Number, i, err)
+				logger.Debug("decoding blob from extrinsic data failed", "avail_block_number", avail_blk.Block.Header.Number, "extrinsic_index", i, "error", err)
 				continue
 			}
 		}


### PR DESCRIPTION
I incorrectly used format string approach to parameterize log messages with variables, but it turned out that `hclog` actually prefers key-value-tuples for arguments.

This commit sweeps avail-settlement codebase for correct logger usage.