### PR TITLE
Implement `BlockBuilderFactory.FromBlockchainHead()`

### DIFF
--- a/pkg/block/builder.go
+++ b/pkg/block/builder.go
@@ -54,6 +54,7 @@ type blockBuilder struct {
 
 type BlockBuilderFactory interface {
 	FromParentHash(hash types.Hash) (Builder, error)
+	FromBlockchainHead() (Builder, error)
 }
 
 type blockBuilderFactory struct {
@@ -68,6 +69,11 @@ func NewBlockBuilderFactory(blockchain *blockchain.Blockchain, executor *state.E
 		executor:   executor,
 		logger:     logger.ResetNamed("block_builder_factory"),
 	}
+}
+
+func (bbf *blockBuilderFactory) FromBlockchainHead() (Builder, error) {
+	hdr := bbf.blockchain.Header()
+	return bbf.FromParentHeader(hdr)
 }
 
 func (bbf *blockBuilderFactory) FromParentHash(parent types.Hash) (Builder, error) {

--- a/tests/block_builder_test.go
+++ b/tests/block_builder_test.go
@@ -27,6 +27,16 @@ func Test_Builder_Construction_FromParentHash(t *testing.T) {
 	}
 }
 
+func Test_Builder_Construction_FromBlockchainHead(t *testing.T) {
+	executor, bchain := test.NewBlockchain(t, staking.NewVerifier(new(test.DumbActiveSequencers), hclog.Default()), getGenesisBasePath())
+
+	bbf := block.NewBlockBuilderFactory(bchain, executor, hclog.Default())
+	_, err := bbf.FromBlockchainHead()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func Test_Builder_Defaults(t *testing.T) {
 	sk := newPrivateKey(t)
 


### PR DESCRIPTION
This change adds a convenient method to construct new block from blockchain `HEAD`.