### PR TITLE
Add support for `block.Builder.SetDifficulty(uint64)`

### DIFF
--- a/pkg/block/builder.go
+++ b/pkg/block/builder.go
@@ -22,6 +22,7 @@ var (
 type Builder interface {
 	SetBlockNumber(number uint64) Builder
 	SetCoinbaseAddress(coinbaseAddr types.Address) Builder
+	SetDifficulty(d uint64) Builder
 	SetExtraDataField(key string, value []byte) Builder
 	SetGasLimit(limit uint64) Builder
 	SetParentStateRoot(parentRoot types.Hash) Builder
@@ -40,6 +41,7 @@ type blockBuilder struct {
 	logger     hclog.Logger
 
 	coinbase   *types.Address
+	difficulty *uint64
 	parentRoot *types.Hash
 	gasLimit   *uint64
 
@@ -108,6 +110,11 @@ func (bb *blockBuilder) SetCoinbaseAddress(coinbaseAddr types.Address) Builder {
 	return bb
 }
 
+func (bb *blockBuilder) SetDifficulty(d uint64) Builder {
+	bb.difficulty = &d
+	return bb
+}
+
 func (bb *blockBuilder) SetExtraDataField(key string, value []byte) Builder {
 	bb.extraData[key] = value
 	return bb
@@ -153,6 +160,11 @@ func (bb *blockBuilder) setDefaults() {
 		*bb.coinbase = types.BytesToAddress(bb.parent.Miner)
 	}
 
+	if bb.difficulty == nil {
+		bb.difficulty = new(uint64)
+		*bb.difficulty = 0
+	}
+
 	if bb.parentRoot == nil {
 		bb.parentRoot = new(types.Hash)
 		*bb.parentRoot = bb.parent.StateRoot
@@ -176,6 +188,7 @@ func (bb *blockBuilder) Build() (*types.Block, error) {
 	bb.setDefaults()
 
 	// Finalize header details before transaction processing.
+	bb.header.Difficulty = *bb.difficulty
 	bb.header.ExtraData = EncodeExtraDataFields(bb.extraData)
 	bb.header.GasLimit = *bb.gasLimit
 	bb.header.Miner = bb.coinbase.Bytes()

--- a/tests/block_builder_test.go
+++ b/tests/block_builder_test.go
@@ -83,6 +83,25 @@ func Test_Builder_Change_CoinbaseAddress(t *testing.T) {
 	}
 }
 
+func Test_Builder_Set_Difficulty(t *testing.T) {
+	sk := newPrivateKey(t)
+
+	expected := uint64(42)
+
+	b, err := newBlockBuilder(t).
+		SetDifficulty(expected).
+		SignWith(sk).
+		Build()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if b.Header.Difficulty != expected {
+		t.Fatalf("block header difficulty: got %d, expected %d", b.Header.Difficulty, expected)
+	}
+}
+
 func Test_Builder_Change_GasLimit(t *testing.T) {
 	sk := newPrivateKey(t)
 


### PR DESCRIPTION
In some situations it's useful to have possibility for adjusting the block difficulty setting (e.g. blockchain fork vs. reorg).