### PR TITLE
Make Avail address configurable

### DIFF
--- a/consensus/avail/avail.go
+++ b/consensus/avail/avail.go
@@ -13,7 +13,6 @@ import (
 	"github.com/0xPolygon/polygon-edge/network"
 	"github.com/0xPolygon/polygon-edge/syncer"
 
-	//"github.com/0xPolygon/polygon-edge/protocol"
 	"github.com/0xPolygon/polygon-edge/secrets"
 	"github.com/0xPolygon/polygon-edge/state"
 	"github.com/0xPolygon/polygon-edge/txpool"
@@ -33,6 +32,10 @@ const (
 	// For now hand coded address of the watch tower
 	WatchTowerAddress = "0xF817d12e6933BbA48C14D4c992719B46aD9f5f61"
 )
+
+type Config struct {
+	AvailAddr string
+}
 
 // Dev consensus protocol seals any new transaction immediately
 type Avail struct {
@@ -63,55 +66,55 @@ type Avail struct {
 	blockTime      time.Duration // Minimum block generation time in seconds
 }
 
-// Factory implements the base factory method
-func Factory(
-	params *consensus.Params,
-) (consensus.Consensus, error) {
-	logger := params.Logger.Named("avail")
+// Factory returns the consensus factory method
+func Factory(config Config) func(params *consensus.Params) (consensus.Consensus, error) {
+	return func(params *consensus.Params) (consensus.Consensus, error) {
+		logger := params.Logger.Named("avail")
 
-	asq := staking.NewActiveSequencersQuerier(params.Blockchain, params.Executor, logger)
+		asq := staking.NewActiveSequencersQuerier(params.Blockchain, params.Executor, logger)
 
-	d := &Avail{
-		logger:         logger,
-		notifyCh:       make(chan struct{}),
-		closeCh:        make(chan struct{}),
-		blockchain:     params.Blockchain,
-		executor:       params.Executor,
-		verifier:       staking.NewVerifier(asq, logger.Named("verifier")),
-		txpool:         params.TxPool,
-		secretsManager: params.SecretsManager,
-		network:        params.Network,
-		blockTime:      time.Duration(params.BlockTime) * time.Second,
-		nodeType:       MechanismType(params.NodeType),
-		syncer: syncer.NewSyncer(
-			params.Logger,
-			params.Network,
-			params.Blockchain,
-			time.Duration(params.BlockTime)*3*time.Second,
-		),
-	}
-
-	var err error
-	if d.mechanisms, err = ParseMechanismConfigTypes(params.Config.Config["mechanisms"]); err != nil {
-		return nil, fmt.Errorf("invalid avail mechanism type/s provided")
-	}
-
-	d.availClient, err = avail.NewClient("ws://127.0.0.1:9944/v1/json-rpc")
-	if err != nil {
-		return nil, err
-	}
-
-	rawInterval, ok := params.Config.Config["interval"]
-	if ok {
-		interval, ok := rawInterval.(uint64)
-		if !ok {
-			return nil, fmt.Errorf("interval expected int")
+		d := &Avail{
+			logger:         logger,
+			notifyCh:       make(chan struct{}),
+			closeCh:        make(chan struct{}),
+			blockchain:     params.Blockchain,
+			executor:       params.Executor,
+			verifier:       staking.NewVerifier(asq, logger.Named("verifier")),
+			txpool:         params.TxPool,
+			secretsManager: params.SecretsManager,
+			network:        params.Network,
+			blockTime:      time.Duration(params.BlockTime) * time.Second,
+			nodeType:       MechanismType(params.NodeType),
+			syncer: syncer.NewSyncer(
+				params.Logger,
+				params.Network,
+				params.Blockchain,
+				time.Duration(params.BlockTime)*3*time.Second,
+			),
 		}
 
-		d.interval = interval
-	}
+		var err error
+		if d.mechanisms, err = ParseMechanismConfigTypes(params.Config.Config["mechanisms"]); err != nil {
+			return nil, fmt.Errorf("invalid avail mechanism type/s provided")
+		}
 
-	return d, nil
+		d.availClient, err = avail.NewClient(config.AvailAddr)
+		if err != nil {
+			return nil, err
+		}
+
+		rawInterval, ok := params.Config.Config["interval"]
+		if ok {
+			interval, ok := rawInterval.(uint64)
+			if !ok {
+				return nil, fmt.Errorf("interval expected int")
+			}
+
+			d.interval = interval
+		}
+
+		return d, nil
+	}
 }
 
 // Initialize initializes the consensus

--- a/server/main.go
+++ b/server/main.go
@@ -18,7 +18,8 @@ const (
 )
 
 func main() {
-	var path string
+	var availAddr, path string
+	flag.StringVar(&availAddr, "avail-addr", "ws://127.0.0.1:9944/v1/json-rpc", "Avail JSON-RPC URL")
 	flag.StringVar(&path, "config-file", "./configs/bootnode.yaml", "Path to the configuration file")
 
 	flag.Parse()
@@ -34,7 +35,7 @@ func main() {
 	log.Printf("Server config: %+v", config)
 
 	// Attach the concensus to the server
-	err = server.RegisterConsensus(AvailConsensus, avail.Factory)
+	err = server.RegisterConsensus(AvailConsensus, avail.Factory(avail.Config{AvailAddr: availAddr}))
 	if err != nil {
 		log.Fatalf("failure to register consensus: %s", err)
 	}


### PR DESCRIPTION
Introduce `avail.Config` that can be used to inject consensus protocol configuration parameters directly from the `server/main.go`, without any need to do custom changes into `polygon-edge` codebase.