### PR TITLE
Implementation of UnStake for watchtower and sequencer

### DIFF
--- a/consensus/avail/avail.go
+++ b/consensus/avail/avail.go
@@ -149,7 +149,7 @@ func (d *Avail) Start() error {
 			}
 		}
 
-		go d.runSequencer(minerKeystore, minerAccount, minerPk)
+		go d.runSequencer(stakingNode, minerKeystore, minerAccount, minerPk)
 	}
 
 	if d.nodeType == Validator {
@@ -169,7 +169,7 @@ func (d *Avail) Start() error {
 			}
 		}
 
-		go d.runWatchTower(wtAccount, wtPK)
+		go d.runWatchTower(stakingNode, wtAccount, wtPK)
 	}
 
 	return nil

--- a/consensus/avail/sequencer.go
+++ b/consensus/avail/sequencer.go
@@ -21,7 +21,7 @@ type transitionInterface interface {
 	Write(txn *types.Transaction) error
 }
 
-func (d *Avail) runSequencer(minerKeystore *keystore.KeyStore, miner accounts.Account, minerPK *keystore.Key) {
+func (d *Avail) runSequencer(stakingNode staking.Node, minerKeystore *keystore.KeyStore, miner accounts.Account, minerPK *keystore.Key) {
 	d.logger.Info("sequencer started")
 
 	for {
@@ -29,6 +29,9 @@ func (d *Avail) runSequencer(minerKeystore *keystore.KeyStore, miner accounts.Ac
 		select {
 		case <-d.nextNotify():
 		case <-d.closeCh:
+			if err := stakingNode.UnStake(minerPK.PrivateKey); err != nil {
+				d.logger.Error("failed to unstake the node: %s", err)
+			}
 			return
 		}
 

--- a/pkg/staking/node.go
+++ b/pkg/staking/node.go
@@ -21,6 +21,7 @@ const (
 type Node interface {
 	ShouldStake(pkey *ecdsa.PrivateKey) bool
 	Stake(amount *big.Int, pkey *ecdsa.PrivateKey) error
+	UnStake(pkey *ecdsa.PrivateKey) error
 }
 
 type node struct {
@@ -53,6 +54,16 @@ func (n *node) Stake(amount *big.Int, pkey *ecdsa.PrivateKey) error {
 	return Stake(
 		n.blockchain, n.executor, n.sender, n.logger, string(n.nodeType),
 		address, pkey, amount, gasLimit, string(n.nodeType),
+	)
+}
+
+func (n *node) UnStake(pkey *ecdsa.PrivateKey) error {
+	pk := pkey.Public().(*ecdsa.PublicKey)
+	address := edge_crypto.PubKeyToAddress(pk)
+	gasLimit := uint64(1_000_000)
+	return UnStake(
+		n.blockchain, n.executor, n.sender, n.logger, address, pkey,
+		gasLimit, string(n.nodeType),
 	)
 }
 

--- a/pkg/staking/staking_test.go
+++ b/pkg/staking/staking_test.go
@@ -126,7 +126,7 @@ func TestIsContractStakedAndUnStaked(t *testing.T) {
 	// DO THE UNSTAKE
 
 	// Staker that we are going to attempt to stake and unstake.
-	unStakeErr := UnStake(blockchain, executor, hclog.Default(), coinbaseAddr, coinbaseSignKey, 1_000_000, "test")
+	unStakeErr := UnStake(blockchain, executor, sender, hclog.Default(), coinbaseAddr, coinbaseSignKey, 1_000_000, "test")
 	tAssert.NoError(unStakeErr)
 
 	// Following test only queries contract to see if it's working.


### PR DESCRIPTION
The current version of implementation extends staking.Node interface with UnStake() and is being executed on close signal for watchtower and sequencer node types.