### PR TITLE
Align `tests` package

### DIFF
--- a/tests/block_builder_test.go
+++ b/tests/block_builder_test.go
@@ -1,4 +1,4 @@
-package test
+package tests
 
 import (
 	"crypto/ecdsa"

--- a/tests/sequencer_test.go
+++ b/tests/sequencer_test.go
@@ -1,14 +1,15 @@
-package test
+package tests
 
 import (
 	"context"
 	"flag"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"net/netip"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/ethereum/go-ethereum/ethclient"
 
 	"github.com/maticnetwork/avail-settlement/consensus/avail"
 )

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -1,4 +1,4 @@
-package test
+package tests
 
 import (
 	"fmt"

--- a/tests/validator_test.go
+++ b/tests/validator_test.go
@@ -1,4 +1,4 @@
-package test
+package tests
 
 import (
 	"errors"

--- a/tests/watchtower_test.go
+++ b/tests/watchtower_test.go
@@ -1,4 +1,4 @@
-package test
+package tests
 
 import (
 	"errors"


### PR DESCRIPTION
Test code under `tests` directory had package named `test`. This change aligns it to `tests` to match the directory name.