### PR TITLE
fix: sync again up to the parent of the received block if needed

### DIFF
--- a/pkg/avail/stream_test.go
+++ b/pkg/avail/stream_test.go
@@ -1,0 +1,41 @@
+package avail
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStreamBlocksCorrectSequence(t *testing.T) {
+	t.Skip("multi-sequencer benchmarks disabled in CI/CD due to lack of Avail")
+
+	offset := 1
+	availClient, err := NewClient("ws://127.0.0.1:9944/v1/json-rpc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	logger := hclog.New(&hclog.LoggerOptions{Name: "polygon", Level: hclog.Off})
+
+	bc := NewBlockStream(availClient, logger, uint64(offset))
+
+	timeout := time.After(20 * time.Second)
+	var blockSeq []uint64
+loop:
+	for {
+		select {
+		case b := <-bc.Chan():
+			blockSeq = append(blockSeq, uint64(b.Block.Header.Number))
+			t.Log("Block number", b.Block.Header.Number)
+		case <-timeout:
+			break loop
+		}
+	}
+	var expectSequence []uint64
+	for i := uint64(offset); i <= blockSeq[len(blockSeq)-1]; i++ {
+		expectSequence = append(expectSequence, i)
+	}
+
+	assert.Equal(t, expectSequence, blockSeq)
+}


### PR DESCRIPTION
Changes:
- Changes the catch up function to be more generic, now it has 2 parameters, offset from and offset to, and it will load al the blocks between that range
- records the latest block after the catch up and then when receiving the first live block compares it against the latest block number
- if the block number is smaller than the latest then it just breaks the loop and doesn't do anything continuing to listen for the next block
- if offset + 1 its greater it calls the catch up function again from the latest to the most recent live block
- if offset + 1 is equal to most recent live block it will send the block through the dataCh as expected