### PR TITLE
Avail fixes

### DIFF
--- a/consensus/avail/avail.go
+++ b/consensus/avail/avail.go
@@ -153,13 +153,13 @@ func Factory(config Config) func(params *consensus.Params) (consensus.Consensus,
 			return nil, err
 		}
 
-		d.availAppID, err = avail.EnsureApplicationKeyExists(d.availClient, AvailApplicationKey, d.availAccount)
+		// 5 AVLs
+		err = avail.DepositBalance(d.availClient, d.availAccount, 5*AVL)
 		if err != nil {
 			return nil, err
 		}
 
-		// 5 AVLs
-		err = avail.DepositBalance(d.availClient, d.availAccount, 5*AVL)
+		d.availAppID, err = avail.EnsureApplicationKeyExists(d.availClient, AvailApplicationKey, d.availAccount)
 		if err != nil {
 			return nil, err
 		}

--- a/consensus/avail/watchtower.go
+++ b/consensus/avail/watchtower.go
@@ -13,7 +13,6 @@ import (
 
 func (d *Avail) runWatchTower(stakingNode staking.Node, myAccount accounts.Account, signKey *keystore.Key) {
 	activeParticipantsQuerier := staking.NewActiveParticipantsQuerier(d.blockchain, d.executor, d.logger)
-	availBlockStream := avail.NewBlockStream(d.availClient, d.logger, 1)
 
 	logger := d.logger.Named("watchtower")
 	watchTower := watchtower.New(d.blockchain, d.executor, logger, types.Address(myAccount.Address), signKey.PrivateKey)
@@ -26,6 +25,9 @@ func (d *Avail) runWatchTower(stakingNode staking.Node, myAccount accounts.Accou
 	}
 
 	d.logger.Debug("ensured watchtower staked")
+
+	// Start watching HEAD from Avail.
+	availBlockStream := avail.NewBlockStream(d.availClient, d.logger, 0)
 
 	callIdx, err := avail.FindCallIndex(d.availClient)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 replace (
 	github.com/0xPolygon/polygon-edge => ./third_party/polygon-edge
-	github.com/centrifuge/go-substrate-rpc-client/v4 => github.com/prabal-banerjee/go-substrate-rpc-client/v4 v4.0.0-avail-alpha
+	github.com/centrifuge/go-substrate-rpc-client/v4 => github.com/prabal-banerjee/go-substrate-rpc-client/v4 v4.0.0-avail-alpha3
 	github.com/maticnetwork/avail-settlement-contracts => ./third_party/avail-settlement-contracts
 )
 

--- a/go.sum
+++ b/go.sum
@@ -614,8 +614,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
-github.com/prabal-banerjee/go-substrate-rpc-client/v4 v4.0.0-avail-alpha h1:TEtcXKtAHM3VrDE5WbsRbsftZDQ3GJltEJj2ZTRBD0A=
-github.com/prabal-banerjee/go-substrate-rpc-client/v4 v4.0.0-avail-alpha/go.mod h1:MDzvG8lkzMGRaO4qzvxdfJtlDtukRPqNVWG9HJybVt0=
+github.com/prabal-banerjee/go-substrate-rpc-client/v4 v4.0.0-avail-alpha3 h1:0oEYxArrr4RXAK1ISztLDbEIKpSE5Eb/Agn9NRwh+nM=
+github.com/prabal-banerjee/go-substrate-rpc-client/v4 v4.0.0-avail-alpha3/go.mod h1:MDzvG8lkzMGRaO4qzvxdfJtlDtukRPqNVWG9HJybVt0=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=

--- a/pkg/avail/account.go
+++ b/pkg/avail/account.go
@@ -99,7 +99,7 @@ func DepositBalance(client Client, account signature.KeyringPair, amount uint64)
 			case status.IsFinalized:
 				return nil
 			case status.IsInBlock:
-				continue
+				return nil
 			default:
 				if status.IsDropped || status.IsInvalid {
 					return fmt.Errorf("unexpected extrinsic status from Avail: %#v", status)


### PR DESCRIPTION
- Upgrade `gsrpc` library to latest patch version.
- Ensure new Avail account deposit & application key existence in the
  right order.
- Start `avail.BlockStream` after the staking to avoid buffering stale
  blocks in the channel.
- Improve logging.
- Start watchtower's `avail.BlockStream` from HEAD.