### PR TITLE
Watchtower SafeCheck

### DIFF
--- a/consensus/avail/fraud.go
+++ b/consensus/avail/fraud.go
@@ -281,7 +281,7 @@ func (f *Fraud) CheckAndSlash() (bool, error) {
 	// Discover who needs to be slashed.
 	// If watchtower produced block that proves sequencer to be corrupted, sequencer needs to be slashed.
 	// If watchtower produced block that proves sequencer to be correct, watchtower needs to be slashed.
-	if err := f.watchtower.Check(maliciousBlock); err != nil {
+	if err := f.watchtower.CheckBlockFully(maliciousBlock); err != nil {
 		f.logger.Warn(
 			"Fraud proof block check confirmed malicious block. Slashing sequencer...",
 			"watchtower_block_hash", f.fraudBlock.Hash(),

--- a/consensus/avail/watchtower.go
+++ b/consensus/avail/watchtower.go
@@ -79,7 +79,7 @@ func (d *Avail) runWatchTower(activeParticipantsQuerier staking.ActiveParticipan
 
 		blksLoop:
 			for _, blk := range blks {
-				err = watchTower.SafeCheck(blk)
+				err = watchTower.CheckBlockFully(blk)
 				if err != nil { //  || blk.Number() == 4  - test the fraud
 					// TODO: We should implement something like SafeCheck() to not return errors that should not
 					// result in creating fraud proofs for blocks/transactions that should not be checked.

--- a/tests/validator_test.go
+++ b/tests/validator_test.go
@@ -52,7 +52,7 @@ func TestValidatorBlockCheck(t *testing.T) {
 			blockBuilder.SetCoinbaseAddress(coinbaseAddr).SignWith(signKey)
 
 			v := validator.New(blockchain, executor, coinbaseAddr, hclog.Default())
-			err = v.Check(tc.block(blockBuilder))
+			err = v.CheckBlockStructure(tc.block(blockBuilder))
 			switch {
 			case err == nil && tc.errorMatcher == nil:
 				// correct; carry on

--- a/tests/watchtower_test.go
+++ b/tests/watchtower_test.go
@@ -51,9 +51,9 @@ func TestWatchTowerBlockCheck(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			wt := watchtower.New(blockchain, executor, nil, nil, hclog.Default(), coinbaseAddr, signKey)
+			wt := watchtower.New(blockchain, executor, nil, watchtower.NoBlockValidation, hclog.Default(), coinbaseAddr, signKey)
 
-			err = wt.Check(tc.block(blockBuilder))
+			err = wt.CheckBlockFully(tc.block(blockBuilder))
 			switch {
 			case err == nil && tc.errorMatcher == nil:
 				// correct; carry on
@@ -82,7 +82,7 @@ func TestWatchTowerBlockConstructFraudProof(t *testing.T) {
 	verifier = staking.NewVerifier(asq, hclog.Default())
 	blockchain.SetConsensus(verifier)
 
-	wt := watchtower.New(blockchain, executor, nil, nil, hclog.Default(), coinbaseAddr, signKey)
+	wt := watchtower.New(blockchain, executor, nil, watchtower.NoBlockValidation, hclog.Default(), coinbaseAddr, signKey)
 
 	stakeAmount := big.NewInt(0).Mul(big.NewInt(20), common.ETH)
 	sender := staking.NewTestAvailSender()
@@ -121,7 +121,7 @@ func TestWatchTowerBlockConstructFraudProof(t *testing.T) {
 			tAssert.NotNil(blockBuilder)
 
 			blk := tc.block(blockBuilder)
-			if err := wt.Check(blk); err != nil {
+			if err := wt.CheckBlockFully(blk); err != nil {
 				fpBlk, err := wt.ConstructFraudproof(blk)
 				tAssert.NoError(err)
 
@@ -134,7 +134,7 @@ func TestWatchTowerBlockConstructFraudProof(t *testing.T) {
 	}
 }
 
-func TestWatchTowerBlockSafeCheckConstructFraudProof(t *testing.T) {
+func TestWatchTowerBlockFullCheck(t *testing.T) {
 	tAssert := assert.New(t)
 	verifier := staking.NewVerifier(new(staking.DumbActiveParticipants), hclog.Default())
 	executor, blockchain := test.NewBlockchain(t, verifier, getGenesisBasePath())
@@ -150,7 +150,7 @@ func TestWatchTowerBlockSafeCheckConstructFraudProof(t *testing.T) {
 
 	validator := validator.New(blockchain, executor, coinbaseAddr, hclog.Default())
 
-	wt := watchtower.New(blockchain, executor, nil, validator, hclog.Default(), coinbaseAddr, signKey)
+	wt := watchtower.New(blockchain, executor, nil, validator.CheckBlockFully, hclog.Default(), coinbaseAddr, signKey)
 
 	stakeAmount := big.NewInt(0).Mul(big.NewInt(20), common.ETH)
 	sender := staking.NewTestAvailSender()
@@ -223,7 +223,7 @@ func TestWatchTowerBlockSafeCheckConstructFraudProof(t *testing.T) {
 			tAssert.NotNil(blockBuilder)
 
 			blk := tc.block(blockBuilder)
-			err = wt.SafeCheck(blk)
+			err = wt.CheckBlockFully(blk)
 			if tc.shouldError {
 				tAssert.Error(err)
 			} else {


### PR DESCRIPTION
Introducing safecheck for watchtower to avoid building fraud proofs on blocks that won't be stored into blockchain (sequencers) after all.