### PR TITLE
Rename `avail.TestSender` to `avail.BlackholeSender`

### DIFF
--- a/consensus/avail/staking_test.go
+++ b/consensus/avail/staking_test.go
@@ -31,7 +31,7 @@ func NewTestAvail(t *testing.T, nodeType MechanismType) (*Avail, staking.ActiveP
 	verifier := staking.NewVerifier(asq, hclog.Default())
 	blockchain.SetConsensus(verifier)
 
-	sender := avail.NewTestSender()
+	sender := avail.NewBlackholeSender()
 	stakingNode := staking.NewNode(blockchain, executor, sender, hclog.Default(), staking.NodeType(nodeType))
 
 	return &Avail{

--- a/pkg/avail/sender.go
+++ b/pkg/avail/sender.go
@@ -22,19 +22,20 @@ type Sender interface {
 // Result contains the final result of block data submission.
 type Result struct{}
 
-type testSender struct{}
+type blackholeSender struct{}
 
-func (t *testSender) Send(blk *edgetypes.Block) error {
+func (t *blackholeSender) Send(blk *edgetypes.Block) error {
 	return nil
 }
 
-func (t *testSender) SendAndWaitForStatus(blk *edgetypes.Block, status types.ExtrinsicStatus) error {
+func (t *blackholeSender) SendAndWaitForStatus(blk *edgetypes.Block, status types.ExtrinsicStatus) error {
 	return nil
 }
 
-// NewSender constructs an Avail block data sender.
-func NewTestSender() Sender {
-	return &testSender{}
+// NewBlackholeSender constructs an Avail block data sender that ignores sent
+// blocks - i.e. blackholes them.
+func NewBlackholeSender() Sender {
+	return &blackholeSender{}
 }
 
 type sender struct {


### PR DESCRIPTION
I already implemented one `BlackholeSender` for my tests, until I noticed the `TestSender`. I figured that blackholing is slightly more descriptive so renamed the existing one.