### PR TITLE
Improve test blockchain construction

### DIFF
--- a/consensus/avail/staking_test.go
+++ b/consensus/avail/staking_test.go
@@ -20,7 +20,7 @@ func getGenesisBasePath() string {
 }
 
 func NewTestAvail(t *testing.T, nodeType MechanismType) (*Avail, staking.ActiveParticipants) {
-	executor, blockchain, txpool := test.NewBlockchainWithTxPool(t, staking.NewVerifier(new(staking.DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	executor, blockchain, txpool := test.NewBlockchainWithTxPool(t, test.NewChain(t, getGenesisBasePath()), staking.NewVerifier(new(staking.DumbActiveParticipants), hclog.Default()))
 	asq := staking.NewActiveParticipantsQuerier(blockchain, executor, hclog.Default())
 
 	balance := big.NewInt(0).Mul(big.NewInt(1000), common.ETH)


### PR DESCRIPTION
In some cases it's necessary to adjust the genesis block for test case, e.g. by providing additional accounts. Therefore it's useful to take the chain spec as a parameter to blockchain construction, instead of the path to genesis JSON.