### PR TITLE
Make `syncer` optional in Avail consensus

### DIFF
--- a/consensus/avail/avail.go
+++ b/consensus/avail/avail.go
@@ -112,27 +112,30 @@ func Factory(config Config) func(params *consensus.Params) (consensus.Consensus,
 		asq := staking.NewActiveParticipantsQuerier(params.Blockchain, params.Executor, logger)
 
 		d := &Avail{
-			logger:         logger,
-			notifyCh:       make(chan struct{}),
-			closeCh:        make(chan struct{}),
-			blockchain:     params.Blockchain,
-			executor:       params.Executor,
-			verifier:       staking.NewVerifier(asq, logger.Named("verifier")),
-			txpool:         params.TxPool,
-			secretsManager: params.SecretsManager,
-			network:        params.Network,
-			blockTime:      time.Duration(params.BlockTime) * time.Second,
-			nodeType:       MechanismType(params.NodeType),
-			syncer: syncer.NewSyncer(
-				params.Logger,
-				params.Network,
-				params.Blockchain,
-				time.Duration(params.BlockTime)*3*time.Second,
-			),
+			logger:                     logger,
+			notifyCh:                   make(chan struct{}),
+			closeCh:                    make(chan struct{}),
+			blockchain:                 params.Blockchain,
+			executor:                   params.Executor,
+			verifier:                   staking.NewVerifier(asq, logger.Named("verifier")),
+			txpool:                     params.TxPool,
+			secretsManager:             params.SecretsManager,
+			network:                    params.Network,
+			blockTime:                  time.Duration(params.BlockTime) * time.Second,
+			nodeType:                   MechanismType(params.NodeType),
 			signKey:                    validatorKey,
 			minerAddr:                  validatorAddr,
 			validator:                  validator.New(params.Blockchain, params.Executor, validatorAddr, logger),
 			blockProductionIntervalSec: DefaultBlockProductionIntervalS,
+		}
+
+		if params.Network != nil {
+			d.syncer = syncer.NewSyncer(
+				params.Logger,
+				params.Network,
+				params.Blockchain,
+				time.Duration(params.BlockTime)*3*time.Second,
+			)
 		}
 
 		if d.mechanisms, err = ParseMechanismConfigTypes(params.Config.Config["mechanisms"]); err != nil {
@@ -248,6 +251,11 @@ func (d *Avail) Start() error {
 }
 
 func (d *Avail) startSyncing() {
+	if d.syncer == nil {
+		d.logger.Warn("syncer not configured")
+		return
+	}
+
 	// Start the syncer
 	err := d.syncer.Start()
 	if err != nil {
@@ -285,7 +293,7 @@ func (d *Avail) PreCommitState(header *types.Header, tx *state.Transition) error
 }
 
 func (d *Avail) GetSyncProgression() *progress.Progression {
-	return nil //d.syncer.GetSyncProgression()
+	return nil // d.syncer.GetSyncProgression()
 }
 
 func (d *Avail) Prepare(header *types.Header) error {

--- a/consensus/avail/staking.go
+++ b/consensus/avail/staking.go
@@ -157,7 +157,7 @@ func (d *Avail) stakeParticipant(shouldWait bool, nodeType string) error {
 func (d *Avail) stakeParticipantThroughTxPool(activeParticipantsQuerier staking.ActiveParticipants) error {
 	// We need to have at least one node available to be able successfully push tx to the neighborhood peers
 	for {
-		if d.network.GetBootnodeConnCount() > 0 {
+		if d.network == nil || d.network.GetBootnodeConnCount() > 0 {
 			break
 		}
 


### PR DESCRIPTION
This is needed for being able to drop networking functionality completely from unit and integration tests.