### PR TITLE
Introduce dummy [Avail] block source

### DIFF
--- a/pkg/avail/block.go
+++ b/pkg/avail/block.go
@@ -10,7 +10,7 @@ type DummyBlockSource struct {
 	blockNumber atomic.Int32
 }
 
-func (dbs *DummyBlockSource) DummyBlock(appID types.U32, callIdx types.CallIndex, extrinsics ...types.Extrinsic) *types.SignedBlock {
+func (dbs *DummyBlockSource) DummyBlock(appID types.UCompact, callIdx types.CallIndex, extrinsics ...types.Extrinsic) *types.SignedBlock {
 	blockNum := dbs.blockNumber.Add(1)
 
 	blk := &types.SignedBlock{


### PR DESCRIPTION
This is a helper for tests to produce compatible dummy Avail blocks with specific extrinsic data in it.

My use case in test-under-development was following:
```go
repeat(3*Times, func() { sendBlock(availClient, bbs.Next()) })
```

`bbs` here is helper that pulls latest block from Edge blockchain and serializes & wraps it in Avail block:
```go
type blockchainBlockStream struct {
        blockchain       *blockchain.Blockchain
        dummyBlockSource *avail.DummyBlockSource
        offset           atomic.Uint64
        last             edgetypes.Hash
}

func (bbs *blockchainBlockStream) Next() *types.SignedBlock {
        hdr := bbs.blockchain.Header()

        // Block until blockchain advances.
        for bbs.offset.Load() >= hdr.Number {
                time.Sleep(time.Second)
                hdr = bbs.blockchain.Header()
        }

        n := bbs.offset.Add(1)
        blk, ok := bbs.blockchain.GetBlockByNumber(n, true)
        if !ok {
                panic("couldn't get block from blockchain")
        }

        return edgeToAvailBlock(bbs.dummyBlockSource, blk)
}

func edgeToAvailBlock(dbs *avail.DummyBlockSource, blk *edgetypes.Block) *types.SignedBlock {
        /* SNIP: code serializing Edge block and constructing DataAvailability.submit_data `Call` containing it */

        return dbs.DummyBlock(0, types.CallIndex{}, types.NewExtrinsic(call))
}
```