### PR TITLE
Refactor test helpers to support benchmark

### DIFF
--- a/consensus/avail/staking_test.go
+++ b/consensus/avail/staking_test.go
@@ -20,7 +20,16 @@ func getGenesisBasePath() string {
 }
 
 func NewTestAvail(t *testing.T, nodeType MechanismType) (*Avail, staking.ActiveParticipants) {
-	executor, blockchain, txpool := test.NewBlockchainWithTxPool(t, test.NewChain(t, getGenesisBasePath()), staking.NewVerifier(new(staking.DumbActiveParticipants), hclog.Default()))
+	chain, err := test.NewChain(getGenesisBasePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	executor, blockchain, txpool, err := test.NewBlockchainWithTxPool(chain, staking.NewVerifier(new(staking.DumbActiveParticipants), hclog.Default()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	asq := staking.NewActiveParticipantsQuerier(blockchain, executor, hclog.Default())
 
 	balance := big.NewInt(0).Mul(big.NewInt(1000), common.ETH)

--- a/pkg/staking/dispute_resolution_test.go
+++ b/pkg/staking/dispute_resolution_test.go
@@ -14,7 +14,8 @@ func TestBeginDisputeResolution(t *testing.T) {
 	tAssert := assert.New(t)
 
 	// TODO: Check if verifier is even necessary to be applied. For now skipping it.
-	executor, blockchain := test.NewBlockchain(t, NewVerifier(new(DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	executor, blockchain, err := test.NewBlockchain(NewVerifier(new(DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	tAssert.Nil(err)
 	tAssert.NotNil(executor)
 	tAssert.NotNil(blockchain)
 
@@ -34,7 +35,7 @@ func TestBeginDisputeResolution(t *testing.T) {
 
 	dr := NewDisputeResolution(blockchain, executor, sender, hclog.Default())
 
-	err := dr.Begin(byzantineSequencerAddr, watchtowerSignKey)
+	err = dr.Begin(byzantineSequencerAddr, watchtowerSignKey)
 	tAssert.NoError(err)
 
 	probationSequencers, err := dr.Get(Sequencer)
@@ -84,7 +85,8 @@ func TestEndDisputeResolution(t *testing.T) {
 	tAssert := assert.New(t)
 
 	// TODO: Check if verifier is even necessary to be applied. For now skipping it.
-	executor, blockchain := test.NewBlockchain(t, NewVerifier(new(DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	executor, blockchain, err := test.NewBlockchain(NewVerifier(new(DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	tAssert.Nil(err)
 	tAssert.NotNil(executor)
 	tAssert.NotNil(blockchain)
 
@@ -106,7 +108,7 @@ func TestEndDisputeResolution(t *testing.T) {
 
 	// BEGIN THE DISPUTE RESOLUTION
 
-	err := dr.Begin(byzantineSequencerAddr, watchtowerSignKey)
+	err = dr.Begin(byzantineSequencerAddr, watchtowerSignKey)
 	tAssert.NoError(err)
 
 	probationSequencers, err := dr.Get(Sequencer)
@@ -137,7 +139,8 @@ func TestFailedEndDisputeResolution(t *testing.T) {
 	tAssert := assert.New(t)
 
 	// TODO: Check if verifier is even necessary to be applied. For now skipping it.
-	executor, blockchain := test.NewBlockchain(t, NewVerifier(new(DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	executor, blockchain, err := test.NewBlockchain(NewVerifier(new(DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	tAssert.Nil(err)
 	tAssert.NotNil(executor)
 	tAssert.NotNil(blockchain)
 
@@ -159,7 +162,7 @@ func TestFailedEndDisputeResolution(t *testing.T) {
 
 	// BEGIN THE DISPUTE RESOLUTION
 
-	err := dr.Begin(byzantineSequencerAddr, byzantineSequencerSignKey)
+	err = dr.Begin(byzantineSequencerAddr, byzantineSequencerSignKey)
 	tAssert.NoError(err)
 
 	probationSequencers, err := dr.Get(Sequencer)

--- a/pkg/staking/rate_participants_test.go
+++ b/pkg/staking/rate_participants_test.go
@@ -14,7 +14,8 @@ func TestMinParticipantRater(t *testing.T) {
 	tAssert := assert.New(t)
 
 	// TODO: Check if verifier is even necessary to be applied. For now skipping it.
-	executor, blockchain := test.NewBlockchain(t, NewVerifier(new(DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	executor, blockchain, err := test.NewBlockchain(NewVerifier(new(DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	tAssert.Nil(err)
 	tAssert.NotNil(executor)
 	tAssert.NotNil(blockchain)
 
@@ -39,7 +40,8 @@ func TestMaxParticipantRater(t *testing.T) {
 	tAssert := assert.New(t)
 
 	// TODO: Check if verifier is even necessary to be applied. For now skipping it.
-	executor, blockchain := test.NewBlockchain(t, NewVerifier(new(DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	executor, blockchain, err := test.NewBlockchain(NewVerifier(new(DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	tAssert.Nil(err)
 	tAssert.NotNil(executor)
 	tAssert.NotNil(blockchain)
 

--- a/pkg/staking/rate_sequencers_test.go
+++ b/pkg/staking/rate_sequencers_test.go
@@ -14,7 +14,8 @@ func TestMinSequencerRater(t *testing.T) {
 	tAssert := assert.New(t)
 
 	// TODO: Check if verifier is even necessary to be applied. For now skipping it.
-	executor, blockchain := test.NewBlockchain(t, NewVerifier(new(DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	executor, blockchain, err := test.NewBlockchain(NewVerifier(new(DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	tAssert.Nil(err)
 	tAssert.NotNil(executor)
 	tAssert.NotNil(blockchain)
 
@@ -39,7 +40,8 @@ func TestMaxSequencerRater(t *testing.T) {
 	tAssert := assert.New(t)
 
 	// TODO: Check if verifier is even necessary to be applied. For now skipping it.
-	executor, blockchain := test.NewBlockchain(t, NewVerifier(new(DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	executor, blockchain, err := test.NewBlockchain(NewVerifier(new(DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	tAssert.Nil(err)
 	tAssert.NotNil(executor)
 	tAssert.NotNil(blockchain)
 

--- a/pkg/staking/rate_watchtowers_test.go
+++ b/pkg/staking/rate_watchtowers_test.go
@@ -14,7 +14,8 @@ func TestMinWatchtowerRater(t *testing.T) {
 	tAssert := assert.New(t)
 
 	// TODO: Check if verifier is even necessary to be applied. For now skipping it.
-	executor, blockchain := test.NewBlockchain(t, NewVerifier(new(DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	executor, blockchain, err := test.NewBlockchain(NewVerifier(new(DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	tAssert.Nil(err)
 	tAssert.NotNil(executor)
 	tAssert.NotNil(blockchain)
 
@@ -39,7 +40,8 @@ func TestMaxWatchtowerRater(t *testing.T) {
 	tAssert := assert.New(t)
 
 	// TODO: Check if verifier is even necessary to be applied. For now skipping it.
-	executor, blockchain := test.NewBlockchain(t, NewVerifier(new(DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	executor, blockchain, err := test.NewBlockchain(NewVerifier(new(DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	tAssert.Nil(err)
 	tAssert.NotNil(executor)
 	tAssert.NotNil(blockchain)
 

--- a/pkg/staking/staking_test.go
+++ b/pkg/staking/staking_test.go
@@ -29,8 +29,8 @@ func TestIsContractDeployed(t *testing.T) {
 	tAssert := assert.New(t)
 
 	// TODO: Check if verifier is even necessary to be applied. For now skipping it.
-	executor, blockchain := test.NewBlockchain(t, nil, getGenesisBasePath())
-
+	executor, blockchain, err := test.NewBlockchain(nil, getGenesisBasePath())
+	tAssert.Nil(err)
 	tAssert.NotNil(executor)
 	tAssert.NotNil(blockchain)
 
@@ -48,7 +48,8 @@ func TestGetSetStakingThreshold(t *testing.T) {
 	tAssert := assert.New(t)
 
 	// TODO: Check if verifier is even necessary to be applied. For now skipping it.
-	executor, blockchain := test.NewBlockchain(t, NewVerifier(new(DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	executor, blockchain, err := test.NewBlockchain(NewVerifier(new(DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	tAssert.Nil(err)
 	tAssert.NotNil(executor)
 	tAssert.NotNil(blockchain)
 
@@ -82,7 +83,8 @@ func TestGetSetStakingThreshold(t *testing.T) {
 func TestIsContractStakedAndUnStaked(t *testing.T) {
 	tAssert := assert.New(t)
 
-	executor, blockchain := test.NewBlockchain(t, NewVerifier(new(DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	executor, blockchain, err := test.NewBlockchain(NewVerifier(new(DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	tAssert.Nil(err)
 	tAssert.NotNil(executor)
 	tAssert.NotNil(blockchain)
 
@@ -140,7 +142,8 @@ func TestIsContractStakedAndUnStaked(t *testing.T) {
 func TestSlashStaker(t *testing.T) {
 	tAssert := assert.New(t)
 
-	executor, blockchain := test.NewBlockchain(t, NewVerifier(new(DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	executor, blockchain, err := test.NewBlockchain(NewVerifier(new(DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	tAssert.Nil(err)
 	tAssert.NotNil(executor)
 	tAssert.NotNil(blockchain)
 
@@ -208,7 +211,7 @@ func TestSlashStaker(t *testing.T) {
 
 	dr := NewDisputeResolution(blockchain, executor, sender, hclog.Default())
 
-	err := dr.Begin(maliciousSequencerAddr, coinbaseSignKey)
+	err = dr.Begin(maliciousSequencerAddr, coinbaseSignKey)
 	tAssert.NoError(err)
 
 	isProbationSequencer, isProbationSequencerErr := dr.Contains(maliciousSequencerAddr, Sequencer)

--- a/tests/block_builder_test.go
+++ b/tests/block_builder_test.go
@@ -21,22 +21,27 @@ import (
 )
 
 func Test_Builder_Construction_FromParentHash(t *testing.T) {
-	executor, bchain := test.NewBlockchain(t, staking.NewVerifier(new(staking.DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	executor, bchain, err := test.NewBlockchain(staking.NewVerifier(new(staking.DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	h := bchain.Genesis()
 
 	bbf := block.NewBlockBuilderFactory(bchain, executor, hclog.Default())
-	_, err := bbf.FromParentHash(h)
-	if err != nil {
+	if _, err := bbf.FromParentHash(h); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func Test_Builder_Construction_FromBlockchainHead(t *testing.T) {
-	executor, bchain := test.NewBlockchain(t, staking.NewVerifier(new(staking.DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	executor, bchain, err := test.NewBlockchain(staking.NewVerifier(new(staking.DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	bbf := block.NewBlockBuilderFactory(bchain, executor, hclog.Default())
-	_, err := bbf.FromBlockchainHead()
-	if err != nil {
+	if _, err := bbf.FromBlockchainHead(); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -151,7 +156,11 @@ func Test_Builder_Change_ParentStateRoot(t *testing.T) {
 }
 
 func Test_Builder_Add_Transaction(t *testing.T) {
-	executor, bchain := test.NewBlockchain(t, staking.NewVerifier(new(staking.DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	executor, bchain, err := test.NewBlockchain(staking.NewVerifier(new(staking.DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	address, privateKey := test.NewAccount(t)
 	address2, _ := test.NewAccount(t)
 
@@ -249,7 +258,11 @@ func newPrivateKey(t *testing.T) *ecdsa.PrivateKey {
 func newBlockBuilder(t *testing.T) block.Builder {
 	t.Helper()
 
-	executor, bchain := test.NewBlockchain(t, staking.NewVerifier(new(staking.DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	executor, bchain, err := test.NewBlockchain(staking.NewVerifier(new(staking.DumbActiveParticipants), hclog.Default()), getGenesisBasePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	h := bchain.Genesis()
 
 	bbf := block.NewBlockBuilderFactory(bchain, executor, hclog.Default())

--- a/tests/validator_test.go
+++ b/tests/validator_test.go
@@ -40,7 +40,11 @@ func TestValidatorBlockCheck(t *testing.T) {
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("case %d: %s", i, tc.name), func(t *testing.T) {
 			verifier := staking.NewVerifier(new(staking.DumbActiveParticipants), hclog.Default())
-			executor, blockchain := test.NewBlockchain(t, verifier, getGenesisBasePath())
+			executor, blockchain, err := test.NewBlockchain(verifier, getGenesisBasePath())
+			if err != nil {
+				t.Fatal(err)
+			}
+
 			coinbaseAddr, signKey := test.NewAccount(t)
 			head := test.GetHeadBlock(t, blockchain)
 
@@ -83,7 +87,11 @@ func TestValidatorApplyBlockToBlockchain(t *testing.T) {
 		t.Run(fmt.Sprintf("case %d: %s", i, tc.name), func(t *testing.T) {
 			verifier := staking.NewVerifier(new(staking.DumbActiveParticipants), hclog.Default())
 
-			executor, blockchain := test.NewBlockchain(t, verifier, getGenesisBasePath())
+			executor, blockchain, err := test.NewBlockchain(verifier, getGenesisBasePath())
+			if err != nil {
+				t.Fatal(err)
+			}
+
 			coinbaseAddr, signKey := test.NewAccount(t)
 			head := test.GetHeadBlock(t, blockchain)
 
@@ -126,7 +134,11 @@ func TestValidatorProcessesFraudproof(t *testing.T) {
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("case %d: %s", i, tc.name), func(t *testing.T) {
 			verifier := staking.NewVerifier(new(staking.DumbActiveParticipants), hclog.Default())
-			executor, blockchain := test.NewBlockchain(t, verifier, getGenesisBasePath())
+			executor, blockchain, err := test.NewBlockchain(verifier, getGenesisBasePath())
+			if err != nil {
+				t.Fatal(err)
+			}
+
 			coinbaseAddr, signKey := test.NewAccount(t)
 			head := test.GetHeadBlock(t, blockchain)
 

--- a/tests/watchtower_test.go
+++ b/tests/watchtower_test.go
@@ -41,7 +41,11 @@ func TestWatchTowerBlockCheck(t *testing.T) {
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("case %d: %s", i, tc.name), func(t *testing.T) {
 			verifier := staking.NewVerifier(new(staking.DumbActiveParticipants), hclog.Default())
-			executor, blockchain := test.NewBlockchain(t, verifier, getGenesisBasePath())
+			executor, blockchain, err := test.NewBlockchain(verifier, getGenesisBasePath())
+			if err != nil {
+				t.Fatal(err)
+			}
+
 			head := test.GetHeadBlock(t, blockchain)
 
 			blockBuilder, err := block.NewBlockBuilderFactory(blockchain, executor, hclog.Default()).FromParentHash(head.Hash())
@@ -69,7 +73,10 @@ func TestWatchTowerBlockCheck(t *testing.T) {
 func TestWatchTowerBlockConstructFraudProof(t *testing.T) {
 	tAssert := assert.New(t)
 	verifier := staking.NewVerifier(new(staking.DumbActiveParticipants), hclog.Default())
-	executor, blockchain := test.NewBlockchain(t, verifier, getGenesisBasePath())
+	executor, blockchain, err := test.NewBlockchain(verifier, getGenesisBasePath())
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	balance := big.NewInt(0).Mul(big.NewInt(1000), common.ETH)
 


### PR DESCRIPTION
Refactoring tests package helper functions and removed testing.T from their arguments to allow better support for prototype benchmark. Updated all tests accordingly as well.  