### PR TITLE
Streamline `avail/consensus` construction

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -64,7 +64,7 @@ func main() {
 		NodeType:     config.NodeType,
 	}
 
-	serverInstance, err := server.NewServer(config.Config, consensus.Factory(cfg))
+	serverInstance, err := server.NewServer(config.Config, cfg)
 	if err != nil {
 		log.Fatalf("failure to start node: %s", err)
 	}

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -274,7 +274,7 @@ func startNode(cfg *edge_server.Config, availAddr, accountPath string, nodeType 
 
 	availSender := avail.NewSender(availClient, appID, availAccount)
 
-	factoryCfg := consensus.Config{
+	consensusCfg := consensus.Config{
 		Bootnode:        bootnode,
 		AvailAccount:    availAccount,
 		AvailClient:     availClient,
@@ -283,7 +283,7 @@ func startNode(cfg *edge_server.Config, availAddr, accountPath string, nodeType 
 		NodeType:        string(nodeType),
 	}
 
-	serverInstance, err := server.NewServer(cfg, consensus.Factory(factoryCfg))
+	serverInstance, err := server.NewServer(cfg, consensusCfg)
 	if err != nil {
 		return nil, fmt.Errorf("failure to start node: %w", err)
 	}


### PR DESCRIPTION
Now that we have our own `server` package in-place, we can remove the last bits of references into pluggable/configurable consensus construction. In this project there will always be only one hard-wired consensus implementation.

With this change we can now also drop the workarounds that were needed to wire in additional dependencies and configuration params into our consensus implementation.

This change is a preparation to allow easy wiring of snapshotter into consensus.