### PR TITLE
Remove unused `executor` from `validator`

### DIFF
--- a/consensus/avail/avail.go
+++ b/consensus/avail/avail.go
@@ -132,7 +132,7 @@ func New(config Config) (consensus.Consensus, error) {
 		nodeType:                   MechanismType(config.NodeType),
 		signKey:                    validatorKey,
 		minerAddr:                  validatorAddr,
-		validator:                  validator.New(config.Blockchain, config.Executor, validatorAddr, logger),
+		validator:                  validator.New(config.Blockchain, validatorAddr, logger),
 		blockProductionIntervalSec: DefaultBlockProductionIntervalS,
 
 		availAccount: config.AvailAccount,

--- a/consensus/avail/sequencer.go
+++ b/consensus/avail/sequencer.go
@@ -53,7 +53,7 @@ type SequencerWorker struct {
 func (sw *SequencerWorker) Run(account accounts.Account, key *keystore.Key) error {
 	t := new(atomic.Int64)
 	activeSequencersQuerier := staking.NewRandomizedActiveSequencersQuerier(t.Load, sw.apq)
-	validator := validator.New(sw.blockchain, sw.executor, sw.nodeAddr, sw.logger)
+	validator := validator.New(sw.blockchain, sw.nodeAddr, sw.logger)
 	watchTower := watchtower.New(sw.blockchain, sw.executor, sw.txpool, sw.logger, types.Address(account.Address), key.PrivateKey)
 
 	enableBlockProductionCh := make(chan bool)

--- a/consensus/avail/validator/validator.go
+++ b/consensus/avail/validator/validator.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/0xPolygon/polygon-edge/blockchain"
-	"github.com/0xPolygon/polygon-edge/state"
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/0xPolygon/polygon-edge/types/buildroot"
 	"github.com/hashicorp/go-hclog"
@@ -41,16 +40,14 @@ type ValidatorSet []types.Address
 
 type validator struct {
 	blockchain *blockchain.Blockchain
-	executor   *state.Executor
 
 	logger           hclog.Logger
 	sequencerAddress types.Address
 }
 
-func New(blockchain *blockchain.Blockchain, executor *state.Executor, sequencer types.Address, logger hclog.Logger) Validator {
+func New(blockchain *blockchain.Blockchain, sequencer types.Address, logger hclog.Logger) Validator {
 	return &validator{
 		blockchain: blockchain,
-		executor:   executor,
 
 		logger:           logger.Named("validator"),
 		sequencerAddress: sequencer,
@@ -111,7 +108,6 @@ func (v *validator) verifyFinalizedBlock(blk *types.Block) error {
 	}
 
 	return nil
-
 }
 
 // verifyBlock does the base (common) block verification steps by

--- a/tests/validator_test.go
+++ b/tests/validator_test.go
@@ -55,7 +55,7 @@ func TestValidatorBlockCheck(t *testing.T) {
 
 			blockBuilder.SetCoinbaseAddress(coinbaseAddr).SignWith(signKey)
 
-			v := validator.New(blockchain, executor, coinbaseAddr, hclog.Default())
+			v := validator.New(blockchain, coinbaseAddr, hclog.Default())
 			err = v.Check(tc.block(blockBuilder))
 			switch {
 			case err == nil && tc.errorMatcher == nil:
@@ -102,7 +102,7 @@ func TestValidatorApplyBlockToBlockchain(t *testing.T) {
 
 			blockBuilder.SetCoinbaseAddress(coinbaseAddr).SignWith(signKey)
 
-			v := validator.New(blockchain, executor, coinbaseAddr, hclog.Default())
+			v := validator.New(blockchain, coinbaseAddr, hclog.Default())
 
 			err = v.Apply(tc.block(blockBuilder))
 			switch {
@@ -149,7 +149,7 @@ func TestValidatorProcessesFraudproof(t *testing.T) {
 
 			blockBuilder.SetCoinbaseAddress(coinbaseAddr).SignWith(signKey)
 
-			v := validator.New(blockchain, executor, coinbaseAddr, hclog.Default())
+			v := validator.New(blockchain, coinbaseAddr, hclog.Default())
 
 			err = v.ProcessFraudproof(tc.block(blockBuilder))
 			switch {


### PR DESCRIPTION
This cleanup simplifies dependencies in some use cases (e.g. archive node).