### PR TITLE
Attach AWS EIP & EBS to instances

### DIFF
--- a/deployment/devnet/avail.service
+++ b/deployment/devnet/avail.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/home/ubuntu/data-avail-linux-aarch64 --dev --ws-external --rpc-external --rpc-cors all
+ExecStart=/home/ubuntu/workspace/data-avail-linux-aarch64 --dev --ws-external --rpc-external --rpc-cors all
 
 [Install]
 WantedBy=multi-user.target

--- a/deployment/devnet/ebs-mount.sh
+++ b/deployment/devnet/ebs-mount.sh
@@ -1,0 +1,10 @@
+#cloud-config
+
+runcmd:
+- 'sudo mkdir /home/ubuntu/workspace -p'
+- 'disk="/dev/nvme1n1"'
+- '[ -z "$(lsblk -no FSTYPE "$disk")" ] && mkfs.ext4 "$disk"' # Format the disk as ext4 if the disk is empty and not formattet
+- 'sudo mount "$disk" /home/ubuntu/workspace -t ext4'
+- 'sudo chown -R ubuntu:ubuntu /home/ubuntu/workspace'
+
+output : { all : '| tee -a /var/log/cloud-init-output.log' }

--- a/deployment/devnet/networking.tf
+++ b/deployment/devnet/networking.tf
@@ -1,6 +1,6 @@
 resource "aws_vpc" "devnet" {
-  cidr_block       = var.devnet_vpc_block
-  instance_tenancy = "default"
+  cidr_block           = var.devnet_vpc_block
+  instance_tenancy     = "default"
   enable_dns_hostnames = true
 
   tags = {
@@ -59,3 +59,36 @@ resource "aws_route_table_association" "public" {
   route_table_id = aws_route_table.devnet_public.id
 }
 
+resource "aws_eip" "bootnode" {
+  instance = aws_instance.bootnode.id
+  vpc      = true
+  depends_on = [
+    aws_internet_gateway.igw
+  ]
+}
+
+resource "aws_eip" "avail" {
+  instance = aws_instance.avail.id
+  vpc      = true
+  depends_on = [
+    aws_internet_gateway.igw
+  ]
+}
+
+resource "aws_eip" "node" {
+  count    = length(aws_instance.node)
+  instance = element(aws_instance.node, count.index).id
+  vpc      = true
+  depends_on = [
+    aws_internet_gateway.igw
+  ]
+}
+
+resource "aws_eip" "watchtower" {
+  count    = length(aws_instance.watchtower)
+  instance = element(aws_instance.watchtower, count.index).id
+  vpc      = true
+  depends_on = [
+    aws_internet_gateway.igw
+  ]
+}

--- a/deployment/devnet/outputs.tf
+++ b/deployment/devnet/outputs.tf
@@ -1,6 +1,11 @@
 output "all_instances" {
   value = local.all_instances
 }
+
+output "all_eips" {
+  value = concat([aws_eip.avail], [aws_eip.bootnode], aws_eip.node, aws_eip.watchtower)
+}
+
 output "ssh_pk" {
   value     = tls_private_key.pk.private_key_pem
   sensitive = true

--- a/deployment/devnet/run-avail.sh
+++ b/deployment/devnet/run-avail.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 wget https://github.com/maticnetwork/avail/releases/download/v1.3.0-rc3/data-avail-linux-aarch64.tar.gz
-tar -xzvf data-avail-linux-aarch64.tar.gz
-sudo mv avail.service /etc/systemd/system/
+tar -xzvf data-avail-linux-aarch64.tar.gz -C ./workspace
+sudo mv ./workspace/avail.service /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl start avail.service
 sudo systemctl enable avail.service

--- a/deployment/devnet/run-node.sh
+++ b/deployment/devnet/run-node.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-./accounts -balance 1000 -avail-addr "ws://${1}:9944/v1/json-rpc" -path "./account-mnemonic"
-sudo chown ubuntu:ubuntu ./data
-sudo mv node.service /etc/systemd/system/
+./workspace/accounts -balance 1000 -avail-addr "ws://${1}:9944/v1/json-rpc" -path "./workspace/account-mnemonic"
+sudo chown ubuntu:ubuntu ./workspace/data
+sudo mv ./workspace/node.service /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl start node.service
 sudo systemctl enable node.service


### PR DESCRIPTION
- create AWS EIP for each ec2 instance so that the ip remains static in case a instance shuts down and comes back again
- create a volume for each ec2 instance so that the data persists in case ec2 instances shut down
- attach the created volumes to the ec2 instances
- mount the volumes with cloud init
- modify the script to use the mounted volumes
- modify the script to use the elastic IPs instead of the allocated public ip of the instance