### PR TITLE
Simplify the `avail.SearchBlock` API

### DIFF
--- a/consensus/avail/syncer.go
+++ b/consensus/avail/syncer.go
@@ -15,7 +15,12 @@ func (d *Avail) getNextAvailBlockNumber() uint64 {
 		return 1
 	}
 
-	blk, err := d.availClient.SearchBlock(0, head.Number, d.syncFunc)
+	callIdx, err := avail.FindCallIndex(d.availClient)
+	if err != nil {
+		return 0
+	}
+
+	blk, err := d.availClient.SearchBlock(0, d.syncFunc(head.Number, callIdx))
 	if err != nil {
 		d.logger.Error("failure to sync node", "error", err)
 		return 0
@@ -107,21 +112,23 @@ func (d *Avail) syncNode() (uint64, error) {
 }
 
 // Searches for the edge block in the Avail and returns back avail block for future catch up by the node
-func (d *Avail) syncFunc(availBlk *avail_types.SignedBlock, targetEdgeBlock uint64, callIdx avail_types.CallIndex) (int, bool, error) {
-	blks, err := block.FromAvail(availBlk, d.availAppID, callIdx, d.logger)
-	if err != nil && err != block.ErrNoExtrinsicFound {
-		return -1, false, err
-	}
+func (d *Avail) syncFunc(targetEdgeBlock uint64, callIdx avail_types.CallIndex) avail.SearchFunc {
+	return func(availBlk *avail_types.SignedBlock) (int, bool, error) {
+		blks, err := block.FromAvail(availBlk, d.availAppID, callIdx, d.logger)
+		if err != nil && err != block.ErrNoExtrinsicFound {
+			return -1, false, err
+		}
 
-	if blks == nil || len(blks) < 1 {
+		if blks == nil || len(blks) < 1 {
+			return -1, false, nil
+		}
+
+		for _, blk := range blks {
+			if blk.Header.Number == targetEdgeBlock {
+				return int(availBlk.Block.Header.Number), true, nil
+			}
+		}
+
 		return -1, false, nil
 	}
-
-	for _, blk := range blks {
-		if blk.Header.Number == targetEdgeBlock {
-			return int(availBlk.Block.Header.Number), true, nil
-		}
-	}
-
-	return -1, false, nil
 }

--- a/pkg/avail/client.go
+++ b/pkg/avail/client.go
@@ -15,9 +15,9 @@ type Client interface {
 	// BlockStream creates a new Avail block stream, starting from block height
 	// `offset`.
 	BlockStream(offset uint64) BlockStream
-	SearchBlock(offset int, targetEdgeBlock uint64, searchFunc SearchFunc) (*types.SignedBlock, error)
 	GenesisHash() types.Hash
 	GetLatestHeader() (*types.Header, error)
+	SearchBlock(offset int, searchFunc SearchFunc) (*types.SignedBlock, error)
 }
 
 type client struct {

--- a/pkg/avail/search.go
+++ b/pkg/avail/search.go
@@ -6,22 +6,15 @@ import (
 	"github.com/centrifuge/go-substrate-rpc-client/v4/types"
 )
 
-// SearchFunc is an interface to function that determines seek offset based on current Avail block.
-type SearchFunc func(*types.SignedBlock, uint64, types.CallIndex) (int, bool, error)
+// SearchFunc is an interface to function that determines seek offset based on
+// current Avail block. The function returns the next block number to continue
+// search from, a boolean whether the searched block was found or an error if
+// something went wrong.
+type SearchFunc func(*types.SignedBlock) (int, bool, error)
 
 // SearchBlock
 // What we really need is to figure out in which
-func (c *client) SearchBlock(offset int, targetEdgeBlock uint64, searchFunc SearchFunc) (*types.SignedBlock, error) {
-	meta, err := c.instance().RPC.State.GetMetadataLatest()
-	if err != nil {
-		return nil, err
-	}
-
-	callIdx, err := meta.FindCallIndex(CallSubmitData)
-	if err != nil {
-		return nil, err
-	}
-
+func (c *client) SearchBlock(offset int, searchFunc SearchFunc) (*types.SignedBlock, error) {
 	// In case offset is zero, it means that we have new chain node and we need to sync it
 	// from latest head in avail towards first block.
 	if offset == 0 {
@@ -42,7 +35,7 @@ func (c *client) SearchBlock(offset int, targetEdgeBlock uint64, searchFunc Sear
 		return nil, err
 	}
 
-	offset, _, err = searchFunc(blk, targetEdgeBlock, callIdx)
+	offset, _, err = searchFunc(blk)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +63,7 @@ func (c *client) SearchBlock(offset int, targetEdgeBlock uint64, searchFunc Sear
 			return nil, err
 		}
 
-		offset, found, err = searchFunc(blk, targetEdgeBlock, callIdx)
+		offset, found, err = searchFunc(blk)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
We should avoid leaking Edge specific details into `avail` package. This change simplifies the `avail.SearchFunc` used by `avail.SearchBlock()` for determining whether the desired block was correct or not.