### PR TITLE
Block producer: `chan bool` to `atomic.Bool`

### DIFF
--- a/consensus/avail/sequencer.go
+++ b/consensus/avail/sequencer.go
@@ -50,11 +50,12 @@ type SequencerWorker struct {
 	closeCh                    chan struct{}
 	blockTime                  time.Duration // Minimum block generation time in seconds
 	blockProductionIntervalSec uint64
+	blockProductionEnabled     *atomic.Bool
 }
 
 func (sw *SequencerWorker) Run(account accounts.Account, key *keystore.Key) error {
 	t := new(atomic.Int64)
-	
+
 	// Return same seed value for the period of  `availWindowLen`.
 	randomSeedFn := func() int64 {
 		return t.Load() / availBlockWindowLen
@@ -63,8 +64,7 @@ func (sw *SequencerWorker) Run(account accounts.Account, key *keystore.Key) erro
 	validator := validator.New(sw.blockchain, sw.nodeAddr, sw.logger)
 	watchTower := watchtower.New(sw.blockchain, sw.executor, sw.txpool, sw.logger, types.Address(account.Address), key.PrivateKey)
 
-	enableBlockProductionCh := make(chan bool)
-	fraudResolver := NewFraudResolver(sw.logger, sw.blockchain, sw.executor, sw.txpool, watchTower, enableBlockProductionCh, sw.nodeAddr, sw.nodeSignKey, sw.availSender, sw.nodeType)
+	fraudResolver := NewFraudResolver(sw.logger, sw.blockchain, sw.executor, sw.txpool, watchTower, sw.blockProductionEnabled, sw.nodeAddr, sw.nodeSignKey, sw.availSender, sw.nodeType)
 
 	callIdx, err := avail.FindCallIndex(sw.availClient)
 	if err != nil {
@@ -78,7 +78,7 @@ func (sw *SequencerWorker) Run(account accounts.Account, key *keystore.Key) erro
 	go fraudResolver.ShouldStopProducingBlocks(sw.apq)
 
 	// Write blocks to the local blockchain and avail in intervals uless block production is stopped.
-	go sw.runWriteBlocksLoop(enableBlockProductionCh, activeSequencersQuerier, fraudResolver, account, key)
+	go sw.runWriteBlocksLoop(activeSequencersQuerier, fraudResolver, account, key)
 
 	// BlockStream watcher must be started after the staking is done. Otherwise
 	// the stream is out-of-sync.
@@ -195,16 +195,16 @@ func (sw *SequencerWorker) Run(account accounts.Account, key *keystore.Key) erro
 			// When availBlockNum is 0, 1, 2 ... (availBlockWindowLen - 1), enable the block production.
 			if availBlockNum%availBlockWindowLen < availBlockWindowLen-1 {
 				sw.logger.Debug("it's my turn; enable block producing", "t", availBlockNum)
-				enableBlockProductionCh <- true
+				sw.blockProductionEnabled.Store(true)
 			} else {
 				// This is the last block of `availBlockWindowLen` -> stop block production to allow nodes to synchronize.
 				sw.logger.Debug("it's my turn; last block on availBlockWindowLen. disabling block production", "t", availBlockNum)
-				enableBlockProductionCh <- false
+				sw.blockProductionEnabled.Store(false)
 			}
 		} else {
 			// Under no circumstances, blocks should be produced when the node is not an active sequencer.
 			sw.logger.Debug("it's not my turn; disable block producing", "t", availBlockNum)
-			enableBlockProductionCh <- false
+			sw.blockProductionEnabled.Store(false)
 		}
 	}
 }
@@ -220,16 +220,14 @@ func (sw *SequencerWorker) IsNextSequencer(activeSequencersQuerier staking.Activ
 }
 
 // runWriteBlocksLoop produces blocks at an interval defined in the blockProductionIntervalSec config option
-func (sw *SequencerWorker) runWriteBlocksLoop(enableBlockProductionCh chan bool, activeSequencersQuerier staking.ActiveSequencers, fraudResolver *Fraud, myAccount accounts.Account, signKey *keystore.Key) {
+func (sw *SequencerWorker) runWriteBlocksLoop(activeSequencersQuerier staking.ActiveSequencers, fraudResolver *Fraud, myAccount accounts.Account, signKey *keystore.Key) {
 	t := time.NewTicker(time.Duration(sw.blockProductionIntervalSec) * time.Second)
 	defer t.Stop()
-
-	shouldProduce := false
 
 	for {
 		select {
 		case <-t.C:
-			if !shouldProduce {
+			if !sw.blockProductionEnabled.Load() {
 				continue
 			}
 
@@ -257,9 +255,6 @@ func (sw *SequencerWorker) runWriteBlocksLoop(enableBlockProductionCh chan bool,
 			if err := sw.writeBlock(myAccount, signKey); err != nil {
 				sw.logger.Error("failed to mine block", "error", err)
 			}
-		case e := <-enableBlockProductionCh:
-			sw.logger.Debug("sequencer block producing status", "should_produce", e)
-			shouldProduce = e
 
 		case <-sw.closeCh:
 			sw.logger.Debug("received stop signal")
@@ -464,5 +459,6 @@ func NewSequencer(
 		availSender:                availSender,
 		blockTime:                  blockTime,
 		blockProductionIntervalSec: blockProductionIntervalSec,
+		blockProductionEnabled:     new(atomic.Bool),
 	}, nil
 }


### PR DESCRIPTION
When signalling when to start/stop block production in block producer, use `atomic.Bool` instead of `chan bool` to avoid wait conditions on goroutine synchronization. Use of channel caused the main sequencing loop to drop behind from Avail HEAD which effectively broke the synchronization of [sequencer] nodes and therefore the whole blockchain consistency. Atomic boolean does the same job but without blocking wait between two goroutines.