### PR TITLE
Add caching `RandomizedActiveSequencersQuerier`

### DIFF
--- a/pkg/staking/sequencers_delayed.go
+++ b/pkg/staking/sequencers_delayed.go
@@ -43,7 +43,10 @@ func (c *cachingRandomizedActiveSequencersQuerier) Contains(addr types.Address) 
 
 	if c.lastSequencers == nil || c.lastSeed != seed {
 		// Refresh cache.
-		c.Get()
+		_, err := c.Get()
+		if err != nil {
+			return false, err
+		}
 	}
 
 	for _, s := range c.lastSequencers {


### PR DESCRIPTION
This is a caching wrapper for `RandomizedActiveSequencersQuerier` in order to avoid querying for active sequencers if the given random seed hasn't changed.

Despite of the naming of some bits, there's a bit of determinism in the seed which explains the necessity of this implementation:

The seed in Avail Settlement Layer is derived from Avail block number and when the active sequencer is selected for certain period of time (i.e. certain number of Avail blocks - `availBlockWindowLen`), the list of active sequencers (or rather, the leader) doesn't change during that. If a sequencer node joins or leaves the active sequencers during that period of time, the underlying list of active sequencers changes and this would cause undeterministic change of current active sequencer (the present leader of that time). This breaks the synchronization of the cluster so therefore once the new window starts, the active sequencers list (and the leader) must be cached until the seed changes (i.e. next window starts).