### PR TITLE
Avail package improvement: Search

### DIFF
--- a/pkg/avail/client.go
+++ b/pkg/avail/client.go
@@ -15,8 +15,8 @@ type Client interface {
 	// BlockStream creates a new Avail block stream, starting from block height
 	// `offset`.
 	BlockStream(offset uint64) BlockStream
-
 	GenesisHash() types.Hash
+	SearchBlock(offset int64, searchFunc SearchFunc) (*types.SignedBlock, error)
 }
 
 type client struct {
@@ -62,6 +62,10 @@ func (c *client) BlockStream(offset uint64) BlockStream {
 
 func (c *client) GenesisHash() types.Hash {
 	return c.genesisHash
+}
+
+func (c *client) GetLatestHeader() (*types.Header, error) {
+	return c.api.RPC.Chain.GetHeaderLatest()
 }
 
 func FindCallIndex(client Client) (types.CallIndex, error) {

--- a/pkg/avail/search.go
+++ b/pkg/avail/search.go
@@ -1,0 +1,75 @@
+package avail
+
+import (
+	"fmt"
+
+	"github.com/centrifuge/go-substrate-rpc-client/v4/types"
+)
+
+// SearchFunc is an interface to function that determines seek offset based on
+// current Avail block. The function returns the next block number to continue
+// search from, a boolean whether the searched block was found or an error if
+// something went wrong.
+type SearchFunc func(*types.SignedBlock) (int64, bool, error)
+
+// SearchBlock
+// What we really need is to figure out in which
+func (c *client) SearchBlock(offset int64, searchFunc SearchFunc) (*types.SignedBlock, error) {
+	// In case offset is zero, it means that we have new chain node and we need to sync it
+	// from latest head in avail towards first block.
+	if offset == 0 {
+		header, err := c.api.RPC.Chain.GetHeaderLatest()
+		if err != nil {
+			return nil, err
+		}
+		offset = int64(header.Number)
+	}
+
+	blkHash, err := c.api.RPC.Chain.GetBlockHash(uint64(offset))
+	if err != nil {
+		return nil, err
+	}
+
+	blk, err := c.api.RPC.Chain.GetBlock(blkHash)
+	if err != nil {
+		return nil, err
+	}
+
+	offset, _, err = searchFunc(blk)
+	if err != nil {
+		return nil, err
+	}
+
+	var found bool
+
+	for {
+		if offset == 0 {
+			return blk, nil
+		}
+
+		if offset < 0 && blk.Block.Header.Number <= 1 {
+			break
+		}
+
+		blkHash, err := c.api.RPC.Chain.GetBlockHash(uint64(blk.Block.Header.Number) + uint64(offset))
+		if err != nil {
+			return nil, err
+		}
+
+		blk, err = c.api.RPC.Chain.GetBlock(blkHash)
+		if err != nil {
+			return nil, err
+		}
+
+		offset, found, err = searchFunc(blk)
+		if err != nil {
+			return nil, err
+		}
+
+		if found {
+			return blk, nil
+		}
+	}
+
+	return nil, fmt.Errorf("can't find block")
+}

--- a/pkg/avail/watcher.go
+++ b/pkg/avail/watcher.go
@@ -35,12 +35,6 @@ func NewBlockDataWatcher(client Client, appID types.UCompact, handler BlockDataH
 		handler: handler,
 		stop:    make(chan struct{}),
 	}
-
-	//err := watcher.start()
-	//if err != nil {
-	//	return nil, err
-	//}
-
 	return &watcher, nil
 }
 


### PR DESCRIPTION
Adding search functionality to the `pkg/avail`. Function looks for all of the blocks from specified `offset` and it requires additional finer granularity `SearchFunc` applied, acting as a filter function. To know when to stop searching or continue.

As well extending avail.Client with searching interface and introducing `GetLatestHeader` function for easier get of the block head for later use by sequencer.