### PR TITLE
Jump multiple blocks at a time when searching block

### DIFF
--- a/consensus/avail/syncer.go
+++ b/consensus/avail/syncer.go
@@ -20,7 +20,7 @@ func (d *Avail) getNextAvailBlockNumber() uint64 {
 		return 0
 	}
 
-	blk, err := d.availClient.SearchBlock(0, d.syncFunc(head.Number, callIdx))
+	blk, err := d.availClient.SearchBlock(0, d.syncFunc(int64(head.Number), callIdx))
 	if err != nil {
 		d.logger.Error("failure to sync node", "error", err)
 		return 0
@@ -111,8 +111,8 @@ func (d *Avail) syncNode() (uint64, error) {
 	return availNextBlockNumber, nil
 }
 
-// Searches for the edge block in the Avail and returns back avail block for future catch up by the node
-func (d *Avail) syncFunc(targetEdgeBlock uint64, callIdx avail_types.CallIndex) avail.SearchFunc {
+// Searches for the edge block in the Avail and returns back avail block for future catch up by the node.
+func (d *Avail) syncFunc(targetEdgeBlock int64, callIdx avail_types.CallIndex) avail.SearchFunc {
 	return func(availBlk *avail_types.SignedBlock) (int64, bool, error) {
 		blks, err := block.FromAvail(availBlk, d.availAppID, callIdx, d.logger)
 		if err != nil && err != block.ErrNoExtrinsicFound {
@@ -122,13 +122,45 @@ func (d *Avail) syncFunc(targetEdgeBlock uint64, callIdx avail_types.CallIndex) 
 		if blks == nil || len(blks) < 1 {
 			return -1, false, nil
 		}
+		availBlockNum := int64(availBlk.Block.Header.Number)
 
+		// Compute Avail block offsets for all the Edge blocks we can find from the
+		// current Avail block extrinsincs.
+		offsets := []int64{}
 		for _, blk := range blks {
-			if blk.Header.Number == targetEdgeBlock {
+			edgeBlockNum := int64(blk.Header.Number)
+
+			switch {
+			case edgeBlockNum > targetEdgeBlock:
+				offsets = append(offsets, availBlockNum-(edgeBlockNum-targetEdgeBlock))
+			case edgeBlockNum == targetEdgeBlock:
 				return int64(availBlk.Block.Header.Number), true, nil
+			case edgeBlockNum < targetEdgeBlock:
+				offsets = append(offsets, availBlockNum+(targetEdgeBlock-edgeBlockNum))
 			}
 		}
 
-		return -1, false, nil
+		// Search the smallest offset from the offsets.
+		var smallest int64
+		for i := 0; i < len(offsets); i++ {
+			// Did we find the targetEdgeBlock from this Avail block?
+			if offsets[i] == 0 {
+				return 0, true, nil
+			}
+
+			if abs(smallest) > abs(offsets[i]) || smallest == 0 {
+				smallest = offsets[i]
+			}
+		}
+
+		return smallest, false, nil
+	}
+}
+
+func abs(x int64) int64 {
+	if x < 0 {
+		return -x
+	} else {
+		return x
 	}
 }


### PR DESCRIPTION
This change computes the offset difference between current Avail block and targeted Edge block. This avoids linear search through Avail and tries to jump ~directly to right Avail block. This does need couple improvements though, but those shall be added later once we get the better understanding and statistics from the settlement layer block production.

Caveats:
- No tests.
- Doesn't account for batching factor.