### PR TITLE
Feat: releaser pipeline

### DIFF
--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -1,0 +1,45 @@
+name: Releaser
+on:
+  push:
+    branches:
+      - prototype
+      - master
+      - main
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+jobs:
+  build_and_publish_linux_arm64:
+    permissions: write-all
+    name: Build and publish for linux arm64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Trigger submodule update
+        env:
+          SSH_KEY_FOR_SUBMODULE: ${{secrets.AVAIL_SETTLEMENT_SECRET_KEY}}
+        run: |
+          mkdir $HOME/.ssh && echo "$SSH_KEY_FOR_SUBMODULE" > $HOME/.ssh/id_rsa && chmod 600 $HOME/.ssh/id_rsa && git submodule update --init --recursive
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - name: Build all go binaries
+        run: make build-all GOOS=linux GOARCH=arm64
+      - name: Add binaries to tar archive
+        run: tar czf avail-settlement-linux-arm64.tar.gz --transform='s,.*/,,g' avail-settlement tools/accounts/accounts tools/e2e/e2e tools/staking/staking
+      - name: Prepare tag name
+        id: prepare
+        run: |
+            TAG=${GITHUB_REF_NAME}
+            echo ::set-output name=tag_name::${TAG}
+      - name: publish binary
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: avail-settlement-linux-arm64.tar.gz
+          release_name: ${{ steps.prepare.outputs.tag_name }}
+          tag: ${{ steps.prepare.outputs.tag_name }}
+          overwrite: true
+          file_glob: true

--- a/Makefile
+++ b/Makefile
@@ -66,26 +66,27 @@ build-e2e:
 	cd tools/e2e && GOOS=${GOOS} GOARCH=${GOARCH} go build -o e2e
 
 build-fraud: build-fraud-contract
-	cd tools/fraud && go build -o fraud
+	cd tools/fraud && GOOS=${GOOS} GOARCH=${GOARCH} go build -o fraud
 
 build-staking:
-	cd tools/staking && go build -o staking
+	cd tools/staking && GOOS=${GOOS} GOARCH=${GOARCH} go build -o staking
 
 build-contract:
 	solc --abi contracts/SetGet/SetGet.sol -o contracts/SetGet/ --overwrite
 	solc --bin contracts/SetGet/SetGet.sol -o contracts/SetGet/ --overwrite
 	abigen --bin=./contracts/SetGet/SetGet.bin --abi=./contracts/SetGet/SetGet.abi --pkg=setget --out=./contracts/SetGet/SetGet.go
 
-build-edge:
-	cd third_party/polygon-edge && make build
-
 tools-wallet:
-	cd tools/wallet && go build
+	cd tools/wallet && GOOS=${GOOS} GOARCH=${GOARCH} go build
 
 tools-account:
 	cd tools/accounts && GOOS=${GOOS} GOARCH=${GOARCH} go build
 
+build-tools: tools-account build-staking build-e2e
+
 build: build-server build-client
+
+build-all: build build-tools
 
 start-bootstrap-sequencer: build
 	rm -rf data/avail-bootnode-1/blockchain/
@@ -107,7 +108,6 @@ start-fraud: build-fraud
 
 start-staking: build-staking 
 	./tools/staking/staking
-
 
 create-bootstrap-sequencer-account: tools-account
 	./tools/accounts/accounts -balance 1000 -path ./configs/account-bootstrap-sequencer


### PR DESCRIPTION
Add github releaser workflow
- This workflow will build and publish the binaries for avail-settlement and some additional tools
- The workflow is triggered by pushes to master, main, prototype, and by tags
- The releases are built only for linux arm64 we can add other architectures and OS'es later

This is needed when we will evolve the deployment scripts so that we can download and deploy the needed versions, we can also do upgrades and so on