### PR TITLE
Fix a rounding bug from the Avail account tool

### DIFF
--- a/tools/accounts/main.go
+++ b/tools/accounts/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"log"
+	"math/big"
 	"os"
 
 	"github.com/maticnetwork/avail-settlement/pkg/avail"
@@ -11,15 +12,16 @@ import (
 const (
 	// 1 AVL == 10^18 Avail fractions.
 	AVL = 1_000_000_000_000_000_000
+
+	maxUint64 = ^uint64(0)
 )
 
 func main() {
-
 	var balance uint64
 	var availAddr, path string
 	flag.StringVar(&availAddr, "avail-addr", "ws://127.0.0.1:9944/v1/json-rpc", "Avail JSON-RPC URL")
 	flag.StringVar(&path, "path", "./configs/account", "Save path for account memonic file")
-	flag.Uint64Var(&balance, "balance", 18, "Path to the configuration file")
+	flag.Uint64Var(&balance, "balance", 18, "Number of AVLs to deposit on the account")
 
 	flag.Parse()
 
@@ -38,6 +40,27 @@ func main() {
 	log.Printf("Created new avail account %+v", availAccount)
 	log.Printf("Depositing %d AVL to '%s'...", balance, availAccount.Address)
 
+	amount := big.NewInt(0).Mul(big.NewInt(0).SetUint64(balance), big.NewInt(AVL))
+
+	// Deposit balance in chunks of maxUint64 (because of the API limitations).
+	for {
+		if amount.IsUint64() {
+			err = avail.DepositBalance(availClient, availAccount, amount.Uint64(), 0)
+			if err != nil {
+				panic(err)
+			}
+
+			break
+		} else {
+			err = avail.DepositBalance(availClient, availAccount, maxUint64, 0)
+			if err != nil {
+				panic(err)
+			}
+
+			amount = big.NewInt(0).Sub(amount, big.NewInt(0).SetUint64(maxUint64))
+		}
+	}
+
 	err = avail.DepositBalance(availClient, availAccount, balance*AVL, 0)
 	if err != nil {
 		panic(err)
@@ -45,7 +68,7 @@ func main() {
 
 	log.Printf("Successfully deposited '%d' AVL to '%s'", balance, availAccount.Address)
 
-	if err := os.WriteFile(path, []byte(availAccount.URI), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(availAccount.URI), 0o644); err != nil {
 		panic(err)
 	}
 


### PR DESCRIPTION
Avail account creation tool didn't account (no pun intended) for integer overflow when computing the Avail deposit value. Instead of simply multiplying two integers, this change now uses `math/big.Int` to calculate the desired account balance to deposit and then proceeds with it in chunks of `maxUint64`.

Also drive-by-fix for balance flag description and octal literal.