### PR TITLE
`avail.Sender.Send()` without waiting for any status

### DIFF
--- a/pkg/avail/sender.go
+++ b/pkg/avail/sender.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	edgetypes "github.com/0xPolygon/polygon-edge/types"
+	gsrpc "github.com/centrifuge/go-substrate-rpc-client/v4"
 	"github.com/centrifuge/go-substrate-rpc-client/v4/signature"
 	"github.com/centrifuge/go-substrate-rpc-client/v4/types"
 	"github.com/centrifuge/go-substrate-rpc-client/v4/types/codec"
@@ -62,75 +63,10 @@ func (s *sender) Send(blk *edgetypes.Block) error {
 		return err
 	}
 
-	meta, err := api.RPC.State.GetMetadataLatest()
+	ext, err := s.prepareExtrinsicForSend(api, blk)
 	if err != nil {
 		return err
 	}
-
-	blob := Blob{
-		Magic: BlobMagic,
-		Data:  blk.MarshalRLP(),
-	}
-
-	var call types.Call
-	{
-		// XXX: This encoding process is an inefficient hack to workaround
-		// problem in the encoding pipeline from client code to Avail server.
-		// `Blob` implements `scale.Encodeable` interface, but it it's passed
-		// directly to `types.NewCall()`, the server will return an error. This
-		// requires further investigation to fix.
-		encodedBytes, err := codec.Encode(blob)
-		if err != nil {
-			return err
-		}
-
-		call, err = types.NewCall(meta, CallSubmitData, encodedBytes)
-		if err != nil {
-			return err
-		}
-	}
-
-	ext := types.NewExtrinsic(call)
-
-	rv, err := api.RPC.State.GetRuntimeVersionLatest()
-	if err != nil {
-		return err
-	}
-
-	key, err := types.CreateStorageKey(meta, "System", "Account", s.signingKeyPair.PublicKey)
-	if err != nil {
-		return err
-	}
-
-	var accountInfo types.AccountInfo
-	ok, err := api.RPC.State.GetStorageLatest(key, &accountInfo)
-	if err != nil || !ok {
-		return fmt.Errorf("couldn't fetch latest account storage info")
-	}
-
-	nonce := uint64(accountInfo.Nonce)
-	if s.nextNonce > nonce {
-		nonce = s.nextNonce
-	}
-	s.nextNonce = nonce + 1
-	o := types.SignatureOptions{
-		// This transaction is Immortal (https://wiki.polkadot.network/docs/build-protocol-info#transaction-mortality)
-		// Hence BlockHash: Genesis Hash.
-		BlockHash:          s.client.GenesisHash(),
-		Era:                types.ExtrinsicEra{IsMortalEra: false},
-		GenesisHash:        s.client.GenesisHash(),
-		Nonce:              types.NewUCompactFromUInt(nonce),
-		SpecVersion:        rv.SpecVersion,
-		Tip:                types.NewUCompactFromUInt(100),
-		AppID:              s.appID,
-		TransactionVersion: rv.TransactionVersion,
-	}
-
-	err = ext.Sign(s.signingKeyPair, o)
-	if err != nil {
-		return err
-	}
-
 	_, err = api.RPC.Author.SubmitExtrinsic(ext)
 	if err != nil {
 		return err
@@ -153,67 +89,7 @@ func (s *sender) SendAndWaitForStatus(blk *edgetypes.Block, dstatus types.Extrin
 		return err
 	}
 
-	meta, err := api.RPC.State.GetMetadataLatest()
-	if err != nil {
-		return err
-	}
-
-	blob := Blob{
-		Magic: BlobMagic,
-		Data:  blk.MarshalRLP(),
-	}
-
-	var call types.Call
-	{
-		// XXX: This encoding process is an inefficient hack to workaround
-		// problem in the encoding pipeline from client code to Avail server.
-		// `Blob` implements `scale.Encodeable` interface, but it it's passed
-		// directly to `types.NewCall()`, the server will return an error. This
-		// requires further investigation to fix.
-		encodedBytes, err := codec.Encode(blob)
-		if err != nil {
-			return err
-		}
-
-		call, err = types.NewCall(meta, CallSubmitData, encodedBytes)
-		if err != nil {
-			return err
-		}
-	}
-
-	ext := types.NewExtrinsic(call)
-
-	rv, err := api.RPC.State.GetRuntimeVersionLatest()
-	if err != nil {
-		return err
-	}
-
-	key, err := types.CreateStorageKey(meta, "System", "Account", s.signingKeyPair.PublicKey)
-	if err != nil {
-		return err
-	}
-
-	var accountInfo types.AccountInfo
-	ok, err := api.RPC.State.GetStorageLatest(key, &accountInfo)
-	if err != nil || !ok {
-		return fmt.Errorf("couldn't fetch latest account storage info")
-	}
-
-	nonce := uint64(accountInfo.Nonce)
-	o := types.SignatureOptions{
-		// This transaction is Immortal (https://wiki.polkadot.network/docs/build-protocol-info#transaction-mortality)
-		// Hence BlockHash: Genesis Hash.
-		BlockHash:          s.client.GenesisHash(),
-		Era:                types.ExtrinsicEra{IsMortalEra: false},
-		GenesisHash:        s.client.GenesisHash(),
-		Nonce:              types.NewUCompactFromUInt(nonce),
-		SpecVersion:        rv.SpecVersion,
-		Tip:                types.NewUCompactFromUInt(100),
-		AppID:              s.appID,
-		TransactionVersion: rv.TransactionVersion,
-	}
-
-	err = ext.Sign(s.signingKeyPair, o)
+	ext, err := s.prepareExtrinsicForSend(api, blk)
 	if err != nil {
 		return err
 	}
@@ -250,4 +126,77 @@ func (s *sender) SendAndWaitForStatus(blk *edgetypes.Block, dstatus types.Extrin
 			return err
 		}
 	}
+}
+
+func (s *sender) prepareExtrinsicForSend(api *gsrpc.SubstrateAPI, blk *edgetypes.Block) (types.Extrinsic, error) {
+	meta, err := api.RPC.State.GetMetadataLatest()
+	if err != nil {
+		return types.Extrinsic{}, err
+	}
+
+	blob := Blob{
+		Magic: BlobMagic,
+		Data:  blk.MarshalRLP(),
+	}
+
+	var call types.Call
+	{
+		// XXX: This encoding process is an inefficient hack to workaround
+		// problem in the encoding pipeline from client code to Avail server.
+		// `Blob` implements `scale.Encodeable` interface, but it it's passed
+		// directly to `types.NewCall()`, the server will return an error. This
+		// requires further investigation to fix.
+		encodedBytes, err := codec.Encode(blob)
+		if err != nil {
+			return types.Extrinsic{}, err
+		}
+
+		call, err = types.NewCall(meta, CallSubmitData, encodedBytes)
+		if err != nil {
+			return types.Extrinsic{}, err
+		}
+	}
+
+	ext := types.NewExtrinsic(call)
+
+	rv, err := api.RPC.State.GetRuntimeVersionLatest()
+	if err != nil {
+		return types.Extrinsic{}, err
+	}
+
+	key, err := types.CreateStorageKey(meta, "System", "Account", s.signingKeyPair.PublicKey)
+	if err != nil {
+		return types.Extrinsic{}, err
+	}
+
+	var accountInfo types.AccountInfo
+	ok, err := api.RPC.State.GetStorageLatest(key, &accountInfo)
+	if err != nil || !ok {
+		return types.Extrinsic{}, fmt.Errorf("couldn't fetch latest account storage info")
+	}
+
+	nonce := uint64(accountInfo.Nonce)
+	if s.nextNonce > nonce {
+		nonce = s.nextNonce
+	}
+	s.nextNonce = nonce + 1
+	o := types.SignatureOptions{
+		// This transaction is Immortal (https://wiki.polkadot.network/docs/build-protocol-info#transaction-mortality)
+		// Hence BlockHash: Genesis Hash.
+		BlockHash:          s.client.GenesisHash(),
+		Era:                types.ExtrinsicEra{IsMortalEra: false},
+		GenesisHash:        s.client.GenesisHash(),
+		Nonce:              types.NewUCompactFromUInt(nonce),
+		SpecVersion:        rv.SpecVersion,
+		Tip:                types.NewUCompactFromUInt(100),
+		AppID:              s.appID,
+		TransactionVersion: rv.TransactionVersion,
+	}
+
+	err = ext.Sign(s.signingKeyPair, o)
+	if err != nil {
+		return types.Extrinsic{}, err
+	}
+
+	return ext, nil
 }


### PR DESCRIPTION
In order to avoid delays in extrinsic submissions, `Send()` uses the `SubmitExtrinsic()` from gsrpc client library, which doesn't wait for any status report. This allows sequencer to batch multiple blocks on Avail in quick fashion, because the current implementation of gsrpc incurs relatively long delay when the response status is waited for.