### PR TITLE
Reduce initial Avail account deposit amount

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,13 +120,13 @@ start-staking: build-staking
 	./tools/staking/staking
 
 create-bootstrap-sequencer-account: tools-account
-	./tools/accounts/accounts -balance 1000 -path ./configs/account-bootstrap-sequencer
+	./tools/accounts/accounts -balance 5 -path ./configs/account-bootstrap-sequencer
 	
 create-sequencer-account: tools-account
-	./tools/accounts/accounts -balance 1000 -path ./configs/account-sequencer
+	./tools/accounts/accounts -balance 5 -path ./configs/account-sequencer
 
 create-watchtower-account: tools-account
-	./tools/accounts/accounts -balance 1000 -path ./configs/account-watchtower
+	./tools/accounts/accounts -balance 5 -path ./configs/account-watchtower
 
 deps:
 ifeq (, $(shell which $(POLYGON_EDGE_BIN)))


### PR DESCRIPTION
Now that `accounts` tool actually deposits the requested amount of AVLs, it takes a long time to complete all necessary transactions. Because `avail-settlement` now has functionality to top-up the Avail account balance when it runs low, the initial deposit doesn't need to be so big. In order to speed up development: reduce initial amount of AVL deposit.