### PR TITLE
Merge separate binaries into one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ build-fraud-contract:
 	abigen --bin=./tools/fraud/contract/Contract.bin --abi=./tools/fraud/contract/Contract.abi --pkg=fraud --out=./tools/fraud/contract/Fraud.go
 
 build-server:
-	GOOS=${GOOS} GOARCH=${GOARCH} go build -o avail-settlement ./cmd/server/...
+	GOOS=${GOOS} GOARCH=${GOARCH} go build -o avail-settlement main.go
 
 build-client:
 	cd client && GOOS=${GOOS} GOARCH=${GOARCH} go build -o client
@@ -86,10 +86,7 @@ build-assm:
 tools-wallet:
 	cd tools/wallet && GOOS=${GOOS} GOARCH=${GOARCH} go build
 
-tools-account:
-	cd tools/accounts && GOOS=${GOOS} GOARCH=${GOARCH} go build
-
-build-tools: tools-account build-staking build-e2e
+build-tools: build-staking build-e2e
 
 build: build-server build-client
 
@@ -121,14 +118,14 @@ start-staking: build-staking
 
 create-accounts: create-bootstrap-sequencer-account create-sequencer-account create-watchtower-account
 
-create-bootstrap-sequencer-account: tools-account
-	./tools/accounts/accounts -balance 6 -path ./configs/account-bootstrap-sequencer
+create-bootstrap-sequencer-account: build-server
+	./avail-settlement availaccount -balance 6 -path ./configs/account-bootstrap-sequencer
 	
-create-sequencer-account: tools-account
-	./tools/accounts/accounts -balance 6 -path ./configs/account-sequencer
+create-sequencer-account: build-server
+	./avail-settlement availaccount -balance 6 -path ./configs/account-sequencer
 
-create-watchtower-account: tools-account
-	./tools/accounts/accounts -balance 6 -path ./configs/account-watchtower
+create-watchtower-account: build-server
+	./avail-settlement availaccount -balance 6 -path ./configs/account-watchtower
 
 deps:
 ifeq (, $(shell which $(POLYGON_EDGE_BIN)))

--- a/cmd/availaccount/main.go
+++ b/cmd/availaccount/main.go
@@ -1,4 +1,4 @@
-package main
+package availaccount
 
 import (
 	"flag"
@@ -20,7 +20,7 @@ const (
 	maxUint64 = ^uint64(0)
 )
 
-func main() {
+func Main() {
 	var balance uint64
 	var availAddr, path string
 	var retry bool

--- a/cmd/keypair/main.go
+++ b/cmd/keypair/main.go
@@ -1,0 +1,5 @@
+package keypair
+
+func Main() {
+	// TODO: Implement Edge keypair creation here.
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,4 +1,4 @@
-package main
+package server
 
 import (
 	"errors"
@@ -15,7 +15,7 @@ import (
 	"github.com/maticnetwork/avail-settlement/server"
 )
 
-func main() {
+func Main() {
 	var bootnode bool
 	var availAddr, path, accountPath string
 	flag.StringVar(&availAddr, "avail-addr", "ws://127.0.0.1:9944/v1/json-rpc", "Avail JSON-RPC URL")

--- a/main.go
+++ b/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/maticnetwork/avail-settlement/cmd/availaccount"
+	"github.com/maticnetwork/avail-settlement/cmd/keypair"
+	"github.com/maticnetwork/avail-settlement/cmd/server"
+)
+
+func main() {
+	fn := server.Main
+
+	if len(os.Args) > 1 && len(os.Args[1]) > 0 && os.Args[1][0] != '-' {
+		switch os.Args[1] {
+		case "server":
+			fn = server.Main
+		case "availaccount":
+			fn = availaccount.Main
+		case "keypair":
+			fn = keypair.Main
+		default:
+			fmt.Fprintf(os.Stderr, "unknown command: %q\n", os.Args[1])
+			return
+		}
+
+		// remove the command from args list.
+		os.Args = append(os.Args[:0], os.Args[1:]...)
+	}
+
+	fn()
+}


### PR DESCRIPTION
This is first step towards single command binary that can do all necessary tasks needed when operating Avail node.

This helps with deployment and initial provisioning of a new node.

This is also lays path towards https://github.com/availproject/avail-settlement/issues/98