### PR TITLE
Bring back `tools/accounts` bin for a bit

### DIFF
--- a/tools/accounts/main.go
+++ b/tools/accounts/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/maticnetwork/avail-settlement/cmd/availaccount"
+
+func main() {
+	availaccount.Main()
+}


### PR DESCRIPTION
Chain of release automation & provisioning experienced a hiccup after the accounts tool was merged into SL binary. This change brings it back for a bit to gain some time for proper fixes.