### PR TITLE
Remove Terraform Cloud from TF stack

### DIFF
--- a/deployment/devnet/main.tf
+++ b/deployment/devnet/main.tf
@@ -1,11 +1,4 @@
 terraform {
-  cloud {
-    organization = "avail"
-
-    workspaces {
-      name = "avail-settlement"
-    }
-  }
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
Terraform Cloud simply does not work. It's extremely unreliable and often results in lost state during creation, which requires tedious and error prone manual resource deletion / cleanup.