### PR TITLE
Wire logger instance into `avail.Client`

### DIFF
--- a/cmd/availaccount/main.go
+++ b/cmd/availaccount/main.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/centrifuge/go-substrate-rpc-client/v4/signature"
+	"github.com/hashicorp/go-hclog"
 	"github.com/spf13/cobra"
 
 	"github.com/maticnetwork/avail-settlement/pkg/avail"
@@ -55,7 +56,7 @@ func GetCommand() *cobra.Command {
 // Example usage:
 // Run("ws://127.0.0.1:9944/v1/json-rpc", "./configs/account", 18, false)
 func Run(availAddr, path string, balance uint64, retry bool) {
-	availClient, err := avail.NewClient(availAddr)
+	availClient, err := avail.NewClient(availAddr, hclog.Default())
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/0xPolygon/polygon-edge/helper/common"
+	"github.com/hashicorp/go-hclog"
 	golog "github.com/ipfs/go-log/v2"
 	"github.com/spf13/cobra"
 
@@ -63,7 +64,7 @@ func Run(availAddr, path, accountPath, fraudListenAddr string, bootnode bool) {
 		log.Fatalf("failed to read Avail account from %q: %s\n", accountPath, err)
 	}
 
-	availClient, err := avail.NewClient(availAddr)
+	availClient, err := avail.NewClient(availAddr, hclog.Default())
 	if err != nil {
 		log.Fatalf("failed to create Avail client: %s\n", err)
 	}

--- a/pkg/avail/client.go
+++ b/pkg/avail/client.go
@@ -23,10 +23,11 @@ type Client interface {
 type client struct {
 	api         *gsrpc.SubstrateAPI
 	genesisHash types.Hash
+	logger      hclog.Logger
 }
 
 // NewClient constructs a new Avail Client for `url`.
-func NewClient(url string) (Client, error) {
+func NewClient(url string, logger hclog.Logger) (Client, error) {
 	api, err := gsrpc.NewSubstrateAPI(url)
 	if err != nil {
 		return nil, err
@@ -41,6 +42,7 @@ func NewClient(url string) (Client, error) {
 	return &client{
 		api:         api,
 		genesisHash: genesisHash,
+		logger:      logger,
 	}, nil
 }
 
@@ -58,7 +60,7 @@ func (c *client) instance() *gsrpc.SubstrateAPI {
 }
 
 func (c *client) BlockStream(offset uint64) BlockStream {
-	return newBlockStream(c, hclog.Default(), offset)
+	return newBlockStream(c, c.logger, offset)
 }
 
 func (c *client) GenesisHash() types.Hash {

--- a/pkg/avail/stream_test.go
+++ b/pkg/avail/stream_test.go
@@ -12,7 +12,7 @@ func TestStreamBlocksCorrectSequence(t *testing.T) {
 	t.Skip("multi-sequencer benchmarks disabled in CI/CD due to lack of Avail")
 
 	offset := 1
-	availClient, err := NewClient("ws://127.0.0.1:9944/v1/json-rpc")
+	availClient, err := NewClient("ws://127.0.0.1:9944/v1/json-rpc", hclog.Default())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/devnet/devnet.go
+++ b/pkg/devnet/devnet.go
@@ -124,7 +124,7 @@ func StartNodes(logger hclog.Logger, bindAddr netip.Addr, availAddr, accountsPat
 		si.config.Chain.Bootnodes = []string{bootnodeAddr}
 		si.config.Network.Chain.Bootnodes = []string{bootnodeAddr}
 
-		srv, err := startNode(si.config, availAddr, si.accountPath, si.fraudAddr, si.nodeType)
+		srv, err := startNode(logger, si.config, availAddr, si.accountPath, si.fraudAddr, si.nodeType)
 		if err != nil {
 			return nil, err
 		}
@@ -247,7 +247,7 @@ func configureNode(pa *PortAllocator, nodeType consensus.MechanismType) (_ *pkg_
 	return cfg, nil
 }
 
-func startNode(cfg *edge_server.Config, availAddr, accountPath, fraudListenerAddr string, nodeType consensus.MechanismType) (*server.Server, error) {
+func startNode(logger hclog.Logger, cfg *edge_server.Config, availAddr, accountPath, fraudListenerAddr string, nodeType consensus.MechanismType) (*server.Server, error) {
 	var bootnode bool
 	if nodeType == consensus.BootstrapSequencer {
 		bootnode = true
@@ -258,7 +258,7 @@ func startNode(cfg *edge_server.Config, availAddr, accountPath, fraudListenerAdd
 		log.Fatalf("failed to read Avail account from %q: %s\n", accountPath, err)
 	}
 
-	availClient, err := avail.NewClient(availAddr)
+	availClient, err := avail.NewClient(availAddr, logger)
 	if err != nil {
 		log.Fatalf("failed to create Avail client: %s\n", err)
 	}
@@ -370,7 +370,7 @@ func createAvailAccounts(logger hclog.Logger, availAddr, accountPath string, nod
 
 	var accountWg sync.WaitGroup
 
-	availClient, err := avail.NewClient(availAddr)
+	availClient, err := avail.NewClient(availAddr, logger)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In order to have control over logging in `avail.Client`, the shared logger instance must be wired in.