### PR TITLE
Fix genesis mechanisms (validator -> watchtower)

### DIFF
--- a/assm/genesis-defaults.json
+++ b/assm/genesis-defaults.json
@@ -46,7 +46,7 @@
                 "mechanisms": [
                     "bootstrap-sequencer",
                     "sequencer",
-                    "validator"
+                    "watchtower"
                 ]
             }
         },

--- a/configs/genesis.json
+++ b/configs/genesis.json
@@ -49,7 +49,7 @@
                 "mechanisms": [
                     "bootstrap-sequencer",
                     "sequencer",
-                    "validator"
+                    "watchtower"
                 ],
                 "blockTime": 1686644797
             }

--- a/pkg/devnet/genesis.json
+++ b/pkg/devnet/genesis.json
@@ -49,7 +49,7 @@
                 "mechanisms": [
                     "bootstrap-sequencer",
                     "sequencer",
-                    "validator"
+                    "watchtower"
                 ],
                 "blockTime": 1686644797
             }


### PR DESCRIPTION
In recent cleanup PR (#200) the `validator` mechanism was removed from supported mechanisms list. The genesis definitions were still listing this legacy mechanism and therefore node failed to start. This change replaces the `validator` mechanism with `watchtower` that was earlier missing from genesis definitions.