### PR TITLE
fix: devnet tool add wait for p2p start and sync plus readme fixes

### DIFF
--- a/docs/demo.md
+++ b/docs/demo.md
@@ -48,7 +48,7 @@ tar -xzvf data-avail-linux-aarch64.tar.gz
 ./data-avail-linux-aarch64 --dev
 ```
 
-## Setting up a Local SL DevNet
+## Setting up a Local OpEVM DevNet
 
 To set up a local DevNet, follow these steps:
 1. Generate an auth token from [github.com/settings/tokens](github.com/settings/tokens).
@@ -82,11 +82,11 @@ To deploy a devnet or a testnet in AWS using terraform follow the instructions [
 1. Open your MetaMask wallet.
 2. Go to **Settings > Networks > Add Network > Add a network manually**.
 3. Fill in the following network details:
-    - Network name: `Avail SL`
+    - Network name: `OpEVM devnet`
     - New RPC URL: `http://127.0.0.1:49601/` (use your bootstrap sequencer rpc link)
     - Chain ID: `100`
     - Currency symbol: `ETH`
-4. Click "Save" and switch to the `Avail Sl` network.
+4. Click "Save" and switch to the `OpEVM devnet` network.
 
 ## Transferring Tokens from the Faucet Account
 

--- a/pkg/devnet/devnet.go
+++ b/pkg/devnet/devnet.go
@@ -142,6 +142,7 @@ func StartNodes(logger hclog.Logger, bindAddr netip.Addr, availAddr, accountsPat
 		ctx.servers[i].server = srv
 
 		logger.Info("started node", "i", i, "nodeType", si.nodeType)
+		time.Sleep(60 * time.Second) // give some time for p2p to start and sync
 	}
 
 	logger.Info("all nodes started", "servers_count", len(ctx.servers))


### PR DESCRIPTION
Basically when devnet command starts it needs a bit of time between nodes for the P2P syncing to occur. Otherwise we get staking issues as txns don't get propagated due to txpool not being ready.